### PR TITLE
Trying something different to fix parse error

### DIFF
--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -32,11 +32,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // create_app(&api_client);
     // delete_app(&api_client);
-    // get_app(&api_client);
-    list_apps(&api_client);
+     get_app(&api_client);
+    // list_apps(&api_client);
     // get_dyno(&api_client);
     // list_dynos(&api_client);
-    // restart_dyno(&api_client);
+     restart_dyno(&api_client);
     // restart_all_dynos(&api_client);
 
     Ok(())

--- a/src/endpoints/apps/mod.rs
+++ b/src/endpoints/apps/mod.rs
@@ -7,6 +7,7 @@ pub use apps::{AppCreate, AppCreateParams, AppDelete, AppDetails, AppList};
 impl ApiResult for App {}
 impl ApiResult for Vec<App> {}
 
+
 /// Heroku App
 /// An app represents the program that you would like to deploy and run on Heroku.
 /// https://devcenter.heroku.com/articles/platform-api-reference#app

--- a/src/framework/endpoint.rs
+++ b/src/framework/endpoint.rs
@@ -3,6 +3,7 @@ use crate::framework::ApiEnvironment;
 use serde::Serialize;
 use url::Url;
 
+#[derive(Debug)]
 pub enum Method {
     Get,
     Post,

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -5,6 +5,7 @@ mod reqwest_utils;
 pub mod response;
 
 use crate::framework::{apiclient::HerokuApiClient, auth::AuthClient, response::match_response};
+use crate::framework::response::{ApiResult, ApiResponse};
 use failure::Fallible;
 use reqwest_utils::match_reqwest_method;
 use serde::Serialize;
@@ -80,6 +81,8 @@ impl<'a> HerokuApiClient for HttpApiClient {
         QueryType: Serialize,
         BodyType: Serialize,
     {
+
+        println!("endpoint method {:?}", endpoint.method());
         // Build the request
         let mut request = self
             .http_client
@@ -100,7 +103,18 @@ impl<'a> HerokuApiClient for HttpApiClient {
 
         let response = request.send()?;
 
-        match_response(response)
+        if endpoint.method() == "Delete" {
+         
+        } else {
+           match_response(response)
+        }
     }
 
 }
+
+fn json_text(resp: &reqwest::blocking::Response) {
+}
+
+//fn is_json<T: ApiResult>(response: &reqwest::blocking::Response) -> bool {
+//    true
+//}

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -5,7 +5,6 @@ mod reqwest_utils;
 pub mod response;
 
 use crate::framework::{apiclient::HerokuApiClient, auth::AuthClient, response::match_response, response::empty_response};
-use crate::framework::response::{ApiResult, ApiResponse};
 use crate::framework::endpoint::Method;
 use failure::Fallible;
 use reqwest_utils::match_reqwest_method;

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -4,7 +4,7 @@ pub mod endpoint;
 mod reqwest_utils;
 pub mod response;
 
-use crate::framework::{apiclient::HerokuApiClient, auth::AuthClient, response::match_response, response::return_empty_response};
+use crate::framework::{apiclient::HerokuApiClient, auth::AuthClient, response::match_response, response::empty_response};
 use crate::framework::response::{ApiResult, ApiResponse};
 use crate::framework::endpoint::Method;
 use failure::Fallible;
@@ -105,7 +105,7 @@ impl<'a> HerokuApiClient for HttpApiClient {
 
         match endpoint.method() {
             Method::Delete => {
-                return_empty_response(response)
+                empty_response(response)
             },
             _ => {
                 match_response(response)

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -4,8 +4,9 @@ pub mod endpoint;
 mod reqwest_utils;
 pub mod response;
 
-use crate::framework::{apiclient::HerokuApiClient, auth::AuthClient, response::match_response};
+use crate::framework::{apiclient::HerokuApiClient, auth::AuthClient, response::match_response, response::return_empty_response};
 use crate::framework::response::{ApiResult, ApiResponse};
+use crate::framework::endpoint::Method;
 use failure::Fallible;
 use reqwest_utils::match_reqwest_method;
 use serde::Serialize;
@@ -82,7 +83,6 @@ impl<'a> HerokuApiClient for HttpApiClient {
         BodyType: Serialize,
     {
 
-        println!("endpoint method {:?}", endpoint.method());
         // Build the request
         let mut request = self
             .http_client
@@ -103,18 +103,13 @@ impl<'a> HerokuApiClient for HttpApiClient {
 
         let response = request.send()?;
 
-        if endpoint.method() == "Delete" {
-         
-        } else {
-           match_response(response)
+        match endpoint.method() {
+            Method::Delete => {
+                return_empty_response(response)
+            },
+            _ => {
+                match_response(response)
+            }
         }
     }
-
 }
-
-fn json_text(resp: &reqwest::blocking::Response) {
-}
-
-//fn is_json<T: ApiResult>(response: &reqwest::blocking::Response) -> bool {
-//    true
-//}

--- a/src/framework/response/mod.rs
+++ b/src/framework/response/mod.rs
@@ -15,6 +15,8 @@ pub fn match_response<T: ApiResult>(resp: reqwest::blocking::Response) -> ApiRes
     }
 }
 
+pub fn return_empty_response<T: ApiResult>(resp: reqwest::blocking::Response) -> ApiResponse<T> {
+
 /// Some endpoints return nothing.
 impl ApiResult for () {}
 

--- a/src/framework/response/mod.rs
+++ b/src/framework/response/mod.rs
@@ -15,13 +15,26 @@ pub fn match_response<T: ApiResult>(resp: reqwest::blocking::Response) -> ApiRes
     }
 }
 
-pub fn return_empty_response(resp: reqwest::blocking::Response) -> ApiResponse<String> {
-    let parsed_resp: Result<std::string::String, reqwest::Error> = resp.text();
+#[derive(Deserialize, Debug)]
+pub struct EmptyResponse {
+   response: String
+}
 
-    match parsed_resp {
-        Ok(response) => Ok(response),
-        Err(e) => Err(e),
+impl EmptyResponse {
+    fn new() {
     }
+}
+
+impl ApiResult for EmptyResponse {
+
+}
+
+pub fn empty_response<T: ApiResult>(resp: reqwest::blocking::Response) -> ApiResponse<T> {
+    let empty_resp = EmptyResponse::new();
+
+    let parsed_resp: Result<T, reqwest::Error> = Ok(empty_resp);
+
+    parsed_resp
 }
 
 /// Some endpoints return nothing.

--- a/src/framework/response/mod.rs
+++ b/src/framework/response/mod.rs
@@ -15,7 +15,14 @@ pub fn match_response<T: ApiResult>(resp: reqwest::blocking::Response) -> ApiRes
     }
 }
 
-pub fn return_empty_response<T: ApiResult>(resp: reqwest::blocking::Response) -> ApiResponse<T> {
+pub fn return_empty_response(resp: reqwest::blocking::Response) -> ApiResponse<String> {
+    let parsed_resp: Result<std::string::String, reqwest::Error> = resp.text();
+
+    match parsed_resp {
+        Ok(response) => Ok(response),
+        Err(e) => Err(e),
+    }
+}
 
 /// Some endpoints return nothing.
 impl ApiResult for () {}


### PR DESCRIPTION
Work in progress

Currently failing with: 

```rust
error[E0308]: mismatched types
  --> /home/nell/heroku-rs/src/framework/response/mod.rs:35:53
   |
32 | pub fn empty_response<T: ApiResult>(resp: reqwest::blocking::Response) -> ApiResponse<T> {
   |                       - this type parameter
...
35 |     let parsed_resp: Result<T, reqwest::Error> = Ok(empty_resp);
   |                                                     ^^^^^^^^^^ expected type parameter `T`, found `()`
   |
   = note: expected type parameter `T`
                   found unit type `()`
   = help: type parameters must be constrained to match other types
   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `heroku_rs`.

To learn more, run the command again with --verbose.
```