### PR TITLE
v0.4/builders- Builder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This will do a GET request on https://api.heroku.com/apps/my_app_name_here
     let query = format!("{}{}", "apps/", "my_app_name_here");
     let method = Method::Get;
-    let response = api_client.request(&custom::CustomEndpointSimple::new(query, method);
+    let response = api_client.request(&custom::CustomEndpointSimple::new(query, method));
 
     Ok(())
 }    

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "heroku_rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "failure",

--- a/examples/src/account_examples.rs
+++ b/examples/src/account_examples.rs
@@ -48,7 +48,6 @@ fn get_key<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
     let response = api_client.request(&account::KeyDetails::new(fingerprint));
     print_response(response);
 }
-
 // get keys
 fn get_keys<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
     let response = api_client.request(&account::KeyList::new());
@@ -57,9 +56,11 @@ fn get_keys<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
 
 // Update invoice address
 fn update_invoice_address<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::InvoiceAddressUpdate::new(
-        None, None, None, None, None, None, None, true,
-    ));
+    let update_invoice = &account::InvoiceAddressUpdate::new()
+        .address_1("Grove Street")
+        .address_2("Not Grove Street")
+        .build();
+    let response = api_client.request(update_invoice);
     print_response(response);
 }
 
@@ -105,25 +106,19 @@ fn get_account_sms_number<ApiClientType: HerokuApiClient>(api_client: &ApiClient
 
 // Confirm password reset.
 fn confirm_password<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let password_id = String::from("123");
-    let old_password = String::from("123");
-    let new_password = String::from("123");
-    let response = api_client.request(&account::PasswordResetConfirm {
-        password_id,
-        params: account::PasswordResetConfirmParams {
-            password: old_password,
-            password_confirmation: new_password,
-        },
-    });
+    let password_id = "123";
+    let password_confimation = &account::PasswordResetConfirm::new(password_id)
+        .password("123")
+        .password_confirmation("123")
+        .build();
+    let response = api_client.request(password_confimation);
     print_response(response);
 }
 
 // Reset password.
 fn reset_account_password<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let email = String::from("EMAIL");
-    let response = api_client.request(&account::PasswordReset {
-        params: account::PasswordResetParams { email },
-    });
+    let email = "EMAIL";
+    let response = api_client.request(&account::PasswordReset::new(email));
     print_response(response);
 }
 
@@ -135,7 +130,7 @@ fn get_account_credits<ApiClientType: HerokuApiClient>(api_client: &ApiClientTyp
 
 // Get account credit.
 fn get_account_credit<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let credit_id = String::from("012abc");
+    let credit_id = "012abc";
 
     let response = api_client.request(&account::AccountCreditDetails { credit_id });
     print_response(response);
@@ -143,50 +138,41 @@ fn get_account_credit<ApiClientType: HerokuApiClient>(api_client: &ApiClientType
 
 // Create account credits.
 fn create_account_credits<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let code1 = Some(String::from("012abc"));
-    let code2 = Some(String::from("012abcd"));
-    let response = api_client.request(&account::AccountCreditCreate {
-        params: account::AccountCreditCreateParams { code1, code2 },
-    });
+    let create_credit = &account::AccountCreditCreate::new()
+        .code_1("012abc")
+        .code_2("012abcd")
+        .build();
+    let response = api_client.request(create_credit);
     print_response(response);
 }
 
 // Delete heroku account app transfer.
 fn delete_account_transfer<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::AppTransferDelete {
-        transfer_id: String::from("ID_HERE"),
-    });
+    let response = api_client.request(&account::AppTransferDelete::new("ID_HERE"));
     print_response(response);
 }
 
 // Patch heroku account app transfer.
 fn patch_account_transfer<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::AppTransferUpdate {
-        transfer_id: String::from("ID_HERE"),
-        params: account::AppTransferUpdateParams {
-            state: String::from("declined"),
-        },
-    });
+    let response = api_client.request(&account::AppTransferUpdate::new("TRANFER_ID", "declined"));
     print_response(response);
 }
 
 // Create heroku account app transfer.
 fn create_account_transfer<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::AppTransferCreate {
-        params: account::AppTransferCreateParams {
-            app: String::from("ID_OR_APPNAME_HERE"),
-            recipient: String::from("ID_OR_EMAIL_HERE"),
-            silent: Some(false),
-        },
-    });
+    let app_id = "APP_ID_HERE";
+    let recipient = "ID_OR_EMAIL_HERE";
+    let transfer = &account::AppTransferCreate::new(app_id, recipient)
+        .silent(false)
+        .build();
+
+    let response = api_client.request(transfer);
     print_response(response);
 }
 
 // Get heroku account app transfer.
 fn get_account_transfer<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::AppTransferDetails {
-        transfer_id: String::from("ID"),
-    });
+    let response = api_client.request(&account::AppTransferDetails::new("transfer_id"));
     print_response(response);
 }
 
@@ -198,18 +184,18 @@ fn get_account_transfers<ApiClientType: HerokuApiClient>(api_client: &ApiClientT
 
 // Patch a specidic heroku account feature.
 fn patch_account_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::AccountFeatureUpdate {
-        feature_id: String::from("team-internal-routing"),
-        params: account::AccountFeatureUpdateParams { enabled: false },
-    });
+    let feature_id = "team-internal-routing";
+    let enable = true;
+
+    let response = api_client.request(&account::AccountFeatureUpdate::new(feature_id, enable));
     print_response(response);
 }
 
 // Get a specidic heroku account feature.
 fn get_account_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::AccountFeatureDetails {
-        feature_id: String::from("team-internal-routing"),
-    });
+    let response = api_client.request(&account::AccountFeatureDetails::new(
+        "team-internal-routing",
+    ));
     print_response(response);
 }
 
@@ -221,7 +207,7 @@ fn get_account_features<ApiClientType: HerokuApiClient>(api_client: &ApiClientTy
 
 // Delete heroku user account. NOTE that this action cannot be undone.
 fn delete_user_account<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let account_id = String::from("USER_ID_OR_EMAIL");
+    let account_id = "USER_ID_OR_EMAIL";
 
     let response = api_client.request(&account::UserAccountDelete { account_id });
     print_response(response);
@@ -229,22 +215,19 @@ fn delete_user_account<ApiClientType: HerokuApiClient>(api_client: &ApiClientTyp
 
 // Patch heroku user account
 fn patch_user_account<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let account_id = String::from("USER_ID_OR_EMAIL");
-    let response = api_client.request(&account::UserAccountUpdate {
-        account_id,
-        params: account::UserAccountUpdateParams {
-            allow_tracking: Some(true),
-            beta: Some(false),
-            name: Some(String::from("Heroku-testing")),
-        },
-    });
+    let account_id = "USER_ID_OR_EMAIL";
+    let account_patch = &account::UserAccountUpdate::new(account_id)
+        .beta(false)
+        .allow_tracking(true)
+        .name("yet-another-name")
+        .build();
+    let response = api_client.request(account_patch);
     print_response(response);
 }
 
 // Get heroku user account by email or id
 fn get_user_account<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let account_id = String::from("USER_ID_OR_EMAIL");
-    let response = api_client.request(&account::UserAccountDetails { account_id });
+    let response = api_client.request(&account::UserAccountDetails::new("USER_ID_OR_EMAIL"));
     print_response(response);
 }
 
@@ -256,13 +239,13 @@ fn delete_account<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
 
 // Patch heroku account
 fn patch_account<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let response = api_client.request(&account::AccountUpdate {
-        params: account::AccountUpdateParams {
-            allow_tracking: Some(true),
-            beta: Some(false),
-            name: Some(String::from("Heroku-test")),
-        },
-    });
+    let patch = &account::AccountUpdate::new()
+        .allow_tracking(true)
+        .beta(false)
+        .name("heroku-examples-new-name")
+        .build();
+    let response = api_client.request(patch);
+
     print_response(response);
 }
 

--- a/examples/src/addon_examples.rs
+++ b/examples/src/addon_examples.rs
@@ -80,15 +80,11 @@ fn get_webhook_delivery<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
 fn update_addon_webhook<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
     let webhook_id = "123";
     let webhook_include = vec!["api:release"];
-    let response = api_client.request(&addons::WebhookUpdate::new(
-        addon_id,
-        webhook_id,
-        None,
-        Some(webhook_include),
-        None,
-        None,
-        None,
-    ));
+    let response = api_client.request(
+        &addons::WebhookUpdate::new(addon_id, webhook_id)
+            .include(webhook_include)
+            .build(),
+    );
     print_response(response);
 }
 
@@ -112,12 +108,12 @@ fn delete_addon_webhook<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
     print_response(response);
 }
 
-// create a new webhookaddon
+// create a new addon webhook
 fn create_addon_webhook<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
     let webhook_include = vec!["api:release"];
     let webhook_level = "notify";
     let webhook_url = "https://www.bing.com";
-    let response = api_client.request(&addons::WebhookCreate::create(
+    let response = api_client.request(&addons::WebhookCreate::new(
         addon_id,
         webhook_include,
         webhook_level,
@@ -161,13 +157,13 @@ fn get_addon_regions_list<T: HerokuApiClient>(api_client: &T) {
 
 // update addon configs
 fn update_addon_config<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
-    let config_key = String::from("key");
-    let config_value = String::from("value");
-    let config = vec![addons::AddonConfig {
-        name: config_key,
-        value: config_value,
-    }];
-    let response = api_client.request(&addons::AddonConfigUpdate::new(addon_id, config));
+    let config_key = "key";
+    let config_value = "value";
+    let response = api_client.request(
+        &addons::AddonConfigUpdate::new(addon_id)
+            .config(config_key, config_value)
+            .build(),
+    );
     print_response(response);
 }
 
@@ -180,7 +176,7 @@ fn get_addon_config_list<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
 // create heroku addon attachment resolution
 fn create_addon_attachment_resolution<T: HerokuApiClient>(api_client: &T) {
     let attachment_id = "123";
-    let response = api_client.request(&addons::AttachmentResolutionCreate::create(attachment_id));
+    let response = api_client.request(&addons::AttachmentResolutionCreate::new(attachment_id));
     print_response(response);
 }
 
@@ -228,9 +224,12 @@ fn get_addon_attachment<T: HerokuApiClient>(api_client: &T) {
 // Create heroku addon attachment
 fn create_addon_attachment<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
     let app_id = "123";
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&addons::AttachmentCreate::create(addon_id, app_id));
+    // `new` method takes only the required parameters
+    let response = api_client.request(
+        &addons::AttachmentCreate::new(addon_id, app_id)
+            .namespace("role:analytics")
+            .build(),
+    );
     print_response(response);
 }
 
@@ -248,9 +247,12 @@ fn provision_addon<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
 
 // Create heroku addon resolution
 fn create_addon_resolution<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&addons::AddonResolutionCreate::create(addon_id));
+    // `new` method takes only the required parameters
+    let response = api_client.request(
+        &addons::AddonResolutionCreate::new(addon_id)
+            .addon_service("heroku-postgresql")
+            .build(),
+    );
     print_response(response);
 }
 
@@ -258,9 +260,8 @@ fn create_addon_resolution<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
 fn create_addon<T: HerokuApiClient>(api_client: &T) {
     let app_id = "123";
     let plan = "heroku-postgresql:dev";
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&addons::AddonCreate::create(app_id, plan));
+    // `new` method takes only the required parameters
+    let response = api_client.request(&addons::AddonCreate::new(app_id, plan));
     print_response(response);
 }
 
@@ -268,9 +269,8 @@ fn create_addon<T: HerokuApiClient>(api_client: &T) {
 fn update_addon<T: HerokuApiClient>(api_client: &T, addon_id: &str) {
     let app_id = "123";
     let plan = "heroku-postgresql:dev";
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&addons::AddonUpdate::create(app_id, addon_id, plan));
+    // `new` method takes only the required parameters
+    let response = api_client.request(&addons::AddonUpdate::new(app_id, addon_id, plan));
     print_response(response);
 }
 

--- a/examples/src/app_review_examples.rs
+++ b/examples/src/app_review_examples.rs
@@ -27,18 +27,12 @@ fn delete_app_review_configuration<T: HerokuApiClient>(api_client: &T) {
 // Update app review config
 fn update_app_review_configuration<T: HerokuApiClient>(api_client: &T) {
     let pipeline_id = "PIPELINE_ID";
-    let automatic_review_apps = Some(true);
-    let base_name = Some("cool-base-name-yo");
-    let response = api_client.request(&review::ReviewAppConfigUpdate::new(
-        pipeline_id,
-        automatic_review_apps,
-        None,
-        None,
-        None,
-        None,
-        None,
-        base_name,
-    ));
+    let response = api_client.request(
+        &review::ReviewAppConfigUpdate::new(pipeline_id)
+            .automatic_review_apps(true)
+            .base_name("cool-base-name-yo")
+            .build(),
+    );
     print_response(response);
 }
 
@@ -53,55 +47,52 @@ fn get_app_review_configuration<T: HerokuApiClient>(api_client: &T) {
 fn enable_app_review_configuration<T: HerokuApiClient>(api_client: &T) {
     let pipeline_id = "PIPELINE_ID";
     let repo = "heroku/heroku-rs-test";
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&review::ReviewAppConfigEnable::create(pipeline_id, repo));
+    // `new` method takes only the required parameters
+    let response = api_client.request(
+        &review::ReviewAppConfigEnable::new(pipeline_id, repo)
+            .automatic_review_apps(true)
+            .build(),
+    );
     print_response(response);
 }
 
 // Delete app review list by review_id
 fn delete_app_review<T: HerokuApiClient>(api_client: &T) {
-    let review_id = String::from("REVIEW_ID");
+    let review_id = "REVIEW_ID";
     let response = api_client.request(&review::ReviewAppDelete { review_id });
     print_response(response);
 }
 
 // Get app review list by pipeline_id
 fn get_app_review_list_by_pipeline<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&review::ReviewAppByPipelineList { pipeline_id });
     print_response(response);
 }
 
 // Get app review by app_id
 fn get_app_review_by_app<T: HerokuApiClient>(api_client: &T) {
-    let app_id = String::from("APP_ID");
+    let app_id = "APP_ID";
     let response = api_client.request(&review::ReviewAppByAppDetails { app_id });
     print_response(response);
 }
 
 // Get app review
 fn get_app_review<T: HerokuApiClient>(api_client: &T) {
-    let review_id = String::from("REVIEW_ID");
+    let review_id = "REVIEW_ID";
     let response = api_client.request(&review::ReviewAppDetails { review_id });
     print_response(response);
 }
 
 // Create app review
 fn create_app_review<T: HerokuApiClient>(api_client: &T) {
-    let branch = String::from("master");
-    let pipeline = String::from("PIPELINE_ID");
-    let source_blob_url =
-        String::from("https://nodejs.org/dist/v0.10.20/node-v0.10.20-linux-x64.tar.gz");
-    let response = api_client.request(&review::ReviewAppCreate {
-        params: review::ReviewAppCreateParams::new(
-            branch,
-            pipeline,
-            source_blob_url,
-            None,
-            None,
-            None,
-        ),
-    });
+    let branch = "master";
+    let pipeline = "PIPELINE_ID";
+    let source_blob_url = "https://nodejs.org/dist/v0.10.20/node-v0.10.20-linux-x64.tar.gz";
+    let response = api_client.request(
+        &review::ReviewAppCreate::new(branch, pipeline, source_blob_url)
+            .fork_repo_id(123)
+            .build(),
+    );
     print_response(response);
 }

--- a/examples/src/apps_examples.rs
+++ b/examples/src/apps_examples.rs
@@ -106,18 +106,13 @@ fn get_app_webhook_events<T: HerokuApiClient>(api_client: &T, app_id: String) {
 
 // Update app SSL
 fn update_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let certificate_chain = Some("chain_here");
-    let private_key = Some("key_here");
     let ssl_id = "123";
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&apps::SSLUpdate::new(
-        &app_id,
-        ssl_id,
-        certificate_chain,
-        private_key,
-        None,
-    ));
+    // `new` method takes only the required parameters
+    let update_ssl = &apps::SSLUpdate::new(&app_id, ssl_id)
+        .certificate_chain("chain_here")
+        .private_key("key_here")
+        .build();
+    let response = api_client.request(update_ssl);
     print_response(response);
 }
 
@@ -125,9 +120,8 @@ fn update_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
 fn create_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
     let certificate_chain = "chain_here";
     let private_key = "key_here";
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&apps::SSLCreate::create(
+    // `new` method takes only the required parameters
+    let response = api_client.request(&apps::SSLCreate::new(
         &app_id,
         certificate_chain,
         private_key,
@@ -203,15 +197,19 @@ fn create_app_sni<T: HerokuApiClient>(api_client: &T, app_id: String) {
 
 // get info about a app setup
 fn get_app_setup<T: HerokuApiClient>(api_client: &T) {
-    let setup_id = String::from("APP_SETUP_ID");
-    let response = api_client.request(&apps::AppSetupDetails { setup_id });
+    let setup_id = "APP_SETUP_ID";
+    let response = api_client.request(&apps::AppSetupDetails::new(setup_id));
     print_response(response);
 }
 
 // create app setup
 fn create_app_setup<T: HerokuApiClient>(api_client: &T) {
     let source_blob_url = "https://github.com/heroku/ruby-rails-sample/tarball/master/";
-    let response = api_client.request(&apps::AppSetupCreate::create(None, source_blob_url, None));
+    let new_app_setup = &apps::AppSetupCreate::new(source_blob_url)
+        .locked(true)
+        .name("gotye-probably")
+        .build();
+    let response = api_client.request(new_app_setup);
     print_response(response);
 }
 
@@ -357,157 +355,120 @@ fn get_app_webhook_deliveries<ApiClientType: HerokuApiClient>(
     api_client: &ApiClientType,
     app_name: String,
 ) {
-    let response = api_client.request(&apps::AppWebhookDeliveryList { app_id: app_name });
+    let response = api_client.request(&apps::AppWebhookDeliveryList { app_id: &app_name });
     print_response(response);
 }
 
 /// Gets details about a specific webhook delivery.
-fn get_app_webhook_delivery<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_name: String,
-) {
-    let webhook_id = String::from("WEBHOOK_DELIVERY_ID");
-    let response = api_client.request(&apps::AppWebhookDetails {
-        app_id: app_name,
-        webhook_id: webhook_id,
-    });
+fn get_app_webhook_delivery<T: HerokuApiClient>(api_client: &T, app_name: String) {
+    let webhook_id = "WEBHOOK_DELIVERY_ID";
+    let response = api_client.request(&apps::AppWebhookDetails::new(&app_name, webhook_id));
+
     print_response(response);
 }
 
 /// Patch a specific webhook.
 fn patch_app_webhook<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let webhook_id = String::from("WEBHOOK_ID");
-    let webhook_include = vec!["api:release".to_owned()];
-    let webhook_level = String::from("notify");
-    let webhook_url = String::from("https://www.bing.com");
-    let response = api_client.request(&apps::AppWebhookUpdate {
-        app_id: app_name,
-        webhook_id: webhook_id,
-        params: apps::AppWebhookUpdateParams {
-            authorization: None,
-            include: Some(webhook_include),
-            level: Some(webhook_level),
-            secret: None,
-            url: Some(webhook_url),
-        },
-    });
+    let webhook_id = "WEBHOOK_ID";
+    let update_app_webhook = &apps::AppWebhookUpdate::new(&app_name, webhook_id)
+        .include(vec!["api:release"])
+        .level("notify")
+        .url("https://www.bing.com")
+        .build();
+
+    let response = api_client.request(update_app_webhook);
     print_response(response);
 }
 
 /// Gets details about a specific webhook.
 fn get_app_webhook<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let webhook_id = String::from("WEBHOOK_ID");
-    let response = api_client.request(&apps::AppWebhookDetails {
-        app_id: app_name,
-        webhook_id: webhook_id,
-    });
+    let webhook_id = "WEBHOOK_ID";
+    let response = api_client.request(&apps::AppWebhookDetails::new(&app_name, webhook_id));
     print_response(response);
 }
 
 /// Gets a list of all webhooks that are available in the specified app.
 fn get_app_webhooks<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppWebhookList { app_id: app_name });
+    let response = api_client.request(&apps::AppWebhookList::new(&app_name));
     print_response(response);
 }
 
 /// Delete a specific app webhook by id
-fn delete_app_webhook<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_name: String,
-) {
-    let webhook_id = String::from("WEBHOOK_ID");
-    let response = api_client.request(&apps::AppWebhookDelete {
-        app_id: app_name,
-        webhook_id: webhook_id,
-    });
+fn delete_app_webhook<T: HerokuApiClient>(api_client: &T, app_name: String) {
+    let webhook_id = "WEBHOOK_ID";
+    let response = api_client.request(&apps::AppWebhookDelete::new(&app_name, webhook_id));
     print_response(response);
 }
 
 /// Create a new app webhook
-fn create_app_webhook<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_name: String,
-) {
-    let response = api_client.request(&apps::AppWebhookCreate {
-        app_id: app_name,
-        params: apps::AppWebhookCreateParams {
-            authorization: None,
-            include: vec!["api:release".to_owned()],
-            level: String::from("notify"),
-            secret: None,
-            url: String::from("https://www.google.com"),
-        },
-    });
+fn create_app_webhook<T: HerokuApiClient>(api_client: &T, app_name: String) {
+    let webhook = &apps::AppWebhookCreate::new(
+        &app_name,
+        vec!["api:release"],
+        "notify",
+        "https://www.google.com",
+    );
+
+    let response = api_client.request(webhook);
     print_response(response);
 }
 
 fn patch_app_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppFeatureUpdate {
-        app_id: app_name,
-        feature_id: String::from("spaces-dns-discovery"),
-        params: apps::AppFeatureUpdateParams { enabled: false },
-    });
+    let update_feature = &apps::AppFeatureUpdate::new(&app_name, "spaces-dns-discovery", false);
+    let response = api_client.request(update_feature);
     print_response(response);
 }
 
 fn get_app_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
     let response = api_client.request(&apps::AppFeatureDetails {
-        app_id: app_name,
-        feature_id: String::from("spaces-dns-discovery"),
+        app_id: &app_name,
+        feature_id: "spaces-dns-discovery",
     });
     print_response(response);
 }
 
 fn get_app_features<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppFeatureList { app_id: app_name });
+    let response = api_client.request(&apps::AppFeatureList { app_id: &app_name });
     print_response(response);
 }
 
 fn refresh_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppRefreshAcm { app_id: app_name });
+    let response = api_client.request(&apps::AppRefreshAcm::new(&app_name));
     print_response(response);
 }
 
 fn disable_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppDisableAcm { app_id: app_name });
+    let response = api_client.request(&apps::AppDisableAcm { app_id: &app_name });
     print_response(response);
 }
 
 fn enable_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppEnableAcm { app_id: app_name });
+    let response = api_client.request(&apps::AppEnableAcm::new(&app_name));
     print_response(response);
 }
 
-fn patch_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let response = api_client.request(&apps::AppUpdate {
-        app_id,
-        params: apps::AppUpdateParams {
-            build_stack: None,
-            maintenance: Some(false),
-            name: None,
-        },
-    });
+fn patch_app<T: HerokuApiClient>(api_client: &T, app_id: String) {
+    let patch = &apps::AppUpdate::new(&app_id)
+        .name("cool-name")
+        .maintenance(false)
+        .build();
+    let response = api_client.request(patch);
     print_response(response);
 }
 
 fn delete_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let response = api_client.request(&apps::AppDelete { app_id });
+    let response = api_client.request(&apps::AppDelete::new(&app_id));
     print_response(response);
 }
 
 fn create_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let response = api_client.request(&apps::AppCreate {
-        params: apps::AppCreateParams {
-            name: Some(app_id),
-            region: None,
-            stack: None,
-        },
-    });
+    let new_app = &apps::AppCreate::new().name(&app_id).build();
+    let response = api_client.request(new_app);
     print_response(response);
 }
 
 fn get_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let response = api_client.request(&apps::AppDetails { app_id });
+    let response = api_client.request(&apps::AppDetails::new(&app_id));
     print_response(response);
 }
 
@@ -516,7 +477,7 @@ fn get_app_raw_response<ApiClientType: HerokuApiClient>(
     app_id: String,
 ) {
     // If successful, this returns a raw reqwest::blocking::response, do whatever with it!
-    let response = api_client.request_raw(&apps::AppDetails { app_id });
+    let response = api_client.request_raw(&apps::AppDetails::new(&app_id));
     match response {
         Ok(res) => println!("Ok: {:?}", res),
         Err(e) => println!("Error: {}", e),
@@ -524,8 +485,8 @@ fn get_app_raw_response<ApiClientType: HerokuApiClient>(
 }
 
 fn list_account_apps<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let account_id = String::from("my-heroku-email@here.io");
-    let resp = api_client.request(&apps::AccountAppList { account_id });
+    let account_id = "my-heroku-email@here.io";
+    let resp = api_client.request(&apps::AccountAppList::new(account_id));
     print_response(resp);
 }
 

--- a/examples/src/apps_examples.rs
+++ b/examples/src/apps_examples.rs
@@ -13,82 +13,82 @@ use std::collections::HashMap;
 pub fn run<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
     let app_name = "heroku-rs-tests";
 
-    create_app(api_client, app_name);
-    delete_app(api_client, app_name); // Careful here :)
-    patch_app(api_client, app_name);
+    // create_app(api_client, app_name);
+    // delete_app(api_client, app_name); // Careful here :)
+    // patch_app(api_client, app_name);
     get_app(api_client, app_name);
-    get_app_raw_response(api_client, app_name);
-    list_apps(api_client);
-    list_account_apps(api_client);
-    get_dyno(api_client, app_name);
-    list_dynos(api_client, app_name);
-    create_dyno_simple(api_client, app_name);
-    create_dyno_complex(api_client, app_name);
-    list_dynos(api_client, app_name);
-    restart_dyno(api_client);
-    restart_all_dynos(api_client, app_name);
-    get_dyno_size_list(api_client);
-    get_dyno_size_details(api_client);
+    // get_app_raw_response(api_client, app_name);
+    // list_apps(api_client);
+    // list_account_apps(api_client);
+    // get_dyno(api_client, app_name);
+    // list_dynos(api_client, app_name);
+    // create_dyno_simple(api_client, app_name);
+    // create_dyno_complex(api_client, app_name);
+    // list_dynos(api_client, app_name);
+    // restart_dyno(api_client);
+    // restart_all_dynos(api_client, app_name);
+    // get_dyno_size_list(api_client);
+    // get_dyno_size_details(api_client);
 
-    enable_app_acm(api_client, app_name);
-    disable_app_acm(api_client, app_name);
-    refresh_app_acm(api_client, app_name);
-    get_app_features(api_client, app_name);
-    get_app_feature(api_client, app_name);
-    patch_app_feature(api_client, app_name);
+    // enable_app_acm(api_client, app_name);
+    // disable_app_acm(api_client, app_name);
+    // refresh_app_acm(api_client, app_name);
+    // get_app_features(api_client, app_name);
+    // get_app_feature(api_client, app_name);
+    // patch_app_feature(api_client, app_name);
 
-    create_app_webhook(api_client, app_name);
-    get_app_webhooks(api_client, app_name);
-    get_app_webhook(api_client, app_name);
-    patch_app_webhook(api_client, app_name);
-    delete_app_webhook(api_client, app_name);
+    // create_app_webhook(api_client, app_name);
+    // get_app_webhooks(api_client, app_name);
+    // get_app_webhook(api_client, app_name);
+    // patch_app_webhook(api_client, app_name);
+    // delete_app_webhook(api_client, app_name);
 
-    get_app_webhook_delivery(api_client, app_name);
-    get_app_webhook_deliveries(api_client, app_name);
+    // get_app_webhook_delivery(api_client, app_name);
+    // get_app_webhook_deliveries(api_client, app_name);
 
-    get_app_webhook_event(api_client, app_name);
-    get_app_webhook_events(api_client, app_name);
+    // get_app_webhook_event(api_client, app_name);
+    // get_app_webhook_events(api_client, app_name);
 
-    create_app_build(api_client, app_name);
-    get_app_builds(api_client, app_name);
-    get_app_build(api_client, app_name);
-    delete_app_build(api_client, app_name);
+    // create_app_build(api_client, app_name);
+    // get_app_builds(api_client, app_name);
+    // get_app_build(api_client, app_name);
+    // delete_app_build(api_client, app_name);
 
-    update_buildpack_installation(api_client, app_name);
-    get_buildpack_installations(api_client, app_name);
+    // update_buildpack_installation(api_client, app_name);
+    // get_buildpack_installations(api_client, app_name);
 
-    create_app_domain(api_client, app_name);
-    get_app_domains(api_client, app_name);
-    get_app_domain(api_client, app_name);
-    delete_app_domain(api_client, app_name);
+    // create_app_domain(api_client, app_name);
+    // get_app_domains(api_client, app_name);
+    // get_app_domain(api_client, app_name);
+    // delete_app_domain(api_client, app_name);
 
-    dyno_action_stop(api_client, app_name);
+    // dyno_action_stop(api_client, app_name);
 
-    get_app_formation(api_client, app_name);
-    list_app_formations(api_client, app_name);
-    update_app_formation(api_client, app_name);
+    // get_app_formation(api_client, app_name);
+    // list_app_formations(api_client, app_name);
+    // update_app_formation(api_client, app_name);
 
-    create_slug(api_client, app_name);
-    get_slug(api_client, app_name);
-    get_app_release(api_client, app_name, "4");
-    list_app_releases(api_client, app_name);
-    create_app_release(api_client, app_name);
-    rollback_app_release(api_client, app_name);
+    // create_slug(api_client, app_name);
+    // get_slug(api_client, app_name);
+    // get_app_release(api_client, app_name, "4");
+    // list_app_releases(api_client, app_name);
+    // create_app_release(api_client, app_name);
+    // rollback_app_release(api_client, app_name);
 
-    create_app_setup(api_client);
-    get_app_setup(api_client);
+    // create_app_setup(api_client);
+    // get_app_setup(api_client);
 
-    create_app_sni(api_client, app_name);
-    get_app_sni(api_client, app_name);
-    get_app_sni_list(api_client, app_name);
-    delete_app_sni(api_client, app_name);
-    update_app_sni(api_client, app_name);
+    // create_app_sni(api_client, app_name);
+    // get_app_sni(api_client, app_name);
+    // get_app_sni_list(api_client, app_name);
+    // delete_app_sni(api_client, app_name);
+    // update_app_sni(api_client, app_name);
 
-    get_app_ssl_list(api_client, app_name);
-    get_app_ssl(api_client, app_name);
-    delete_app_ssl(api_client, app_name); // Careful here.
-    create_app_ssl(api_client, app_name);
-    update_app_ssl(api_client, app_name);
+    // get_app_ssl_list(api_client, app_name);
+    // get_app_ssl(api_client, app_name);
+    // delete_app_ssl(api_client, app_name); // Careful here.
+    // create_app_ssl(api_client, app_name);
+    // update_app_ssl(api_client, app_name);
 }
 
 // get a specific webhook event
@@ -561,11 +561,7 @@ fn create_app_release<ApiClientType: HerokuApiClient>(api_client: &ApiClientType
 }
 
 fn rollback_app_release<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
-    let resp = api_client.request(&releases::ReleaseRollback {
-        app_id,
-        params: releases::ReleaseRollbackParams {
-            release: "v17",
-        },
-    });
+    let release_to_rollback = "v17";
+    let resp = api_client.request(&releases::ReleaseRollback::new(app_id, release_to_rollback));
     print_response(resp);
 }

--- a/examples/src/apps_examples.rs
+++ b/examples/src/apps_examples.rs
@@ -11,104 +11,104 @@ use heroku_rs::framework::apiclient::HerokuApiClient;
 use std::collections::HashMap;
 
 pub fn run<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let app_name = String::from("heroku-rs-tests");
+    let app_name = "heroku-rs-tests";
 
-    // create_app(api_client, app_name);
-    // delete_app(api_client, app_name); // Careful here :)
-    // patch_app(api_client, app_name);
+    create_app(api_client, app_name);
+    delete_app(api_client, app_name); // Careful here :)
+    patch_app(api_client, app_name);
     get_app(api_client, app_name);
-    // get_app_raw_response(api_client, app_name);
-    // list_apps(api_client);
-    // list_account_apps(api_client);
-    // get_dyno(api_client, app_name);
-    // list_dynos(api_client, app_name);
-    // create_dyno_simple(api_client, app_name);
-    // create_dyno_complex(api_client, app_name);
-    // list_dynos(api_client, app_name);
-    // restart_dyno(api_client);
-    // restart_all_dynos(api_client, app_name);
-    // get_dyno_size_list(api_client);
-    // get_dyno_size_details(api_client);
+    get_app_raw_response(api_client, app_name);
+    list_apps(api_client);
+    list_account_apps(api_client);
+    get_dyno(api_client, app_name);
+    list_dynos(api_client, app_name);
+    create_dyno_simple(api_client, app_name);
+    create_dyno_complex(api_client, app_name);
+    list_dynos(api_client, app_name);
+    restart_dyno(api_client);
+    restart_all_dynos(api_client, app_name);
+    get_dyno_size_list(api_client);
+    get_dyno_size_details(api_client);
 
-    // enable_app_acm(api_client, app_name);
-    // disable_app_acm(api_client, app_name);
-    // refresh_app_acm(api_client, app_name);
-    // get_app_features(api_client, app_name);
-    // get_app_feature(api_client, app_name);
-    // patch_app_feature(api_client, app_name);
+    enable_app_acm(api_client, app_name);
+    disable_app_acm(api_client, app_name);
+    refresh_app_acm(api_client, app_name);
+    get_app_features(api_client, app_name);
+    get_app_feature(api_client, app_name);
+    patch_app_feature(api_client, app_name);
 
-    // create_app_webhook(api_client, app_name);
-    // get_app_webhooks(api_client, app_name);
-    // get_app_webhook(api_client, app_name);
-    // patch_app_webhook(api_client, app_name);
-    // delete_app_webhook(api_client, app_name);
+    create_app_webhook(api_client, app_name);
+    get_app_webhooks(api_client, app_name);
+    get_app_webhook(api_client, app_name);
+    patch_app_webhook(api_client, app_name);
+    delete_app_webhook(api_client, app_name);
 
-    // get_app_webhook_delivery(api_client, app_name);
-    // get_app_webhook_deliveries(api_client, app_name);
+    get_app_webhook_delivery(api_client, app_name);
+    get_app_webhook_deliveries(api_client, app_name);
 
-    // get_app_webhook_event(api_client, app_name);
-    // get_app_webhook_events(api_client, app_name);
+    get_app_webhook_event(api_client, app_name);
+    get_app_webhook_events(api_client, app_name);
 
-    // create_app_build(api_client, app_name);
-    // get_app_builds(api_client, app_name);
-    // get_app_build(api_client, app_name);
-    // delete_app_build(api_client, app_name);
+    create_app_build(api_client, app_name);
+    get_app_builds(api_client, app_name);
+    get_app_build(api_client, app_name);
+    delete_app_build(api_client, app_name);
 
-    // update_buildpack_installation(api_client, app_name);
-    // get_buildpack_installations(api_client, app_name);
+    update_buildpack_installation(api_client, app_name);
+    get_buildpack_installations(api_client, app_name);
 
-    // create_app_domain(api_client, app_name);
-    // get_app_domains(api_client, app_name);
-    // get_app_domain(api_client, app_name);
-    // delete_app_domain(api_client, app_name);
+    create_app_domain(api_client, app_name);
+    get_app_domains(api_client, app_name);
+    get_app_domain(api_client, app_name);
+    delete_app_domain(api_client, app_name);
 
-    // dyno_action_stop(api_client, app_name);
+    dyno_action_stop(api_client, app_name);
 
-    // get_app_formation(api_client, app_name);
-    // list_app_formations(api_client, app_name);
-    // update_app_formation(api_client, app_name);
+    get_app_formation(api_client, app_name);
+    list_app_formations(api_client, app_name);
+    update_app_formation(api_client, app_name);
 
-    // create_slug(api_client, app_name);
-    // get_slug(api_client, app_name);
-    // get_app_release(api_client, app_name, "4".to_string());
-    // list_app_releases(api_client, app_name);
-    // create_app_release(api_client, app_name);
-    //  rollback_app_release(api_client, app_name);
+    create_slug(api_client, app_name);
+    get_slug(api_client, app_name);
+    get_app_release(api_client, app_name, "4");
+    list_app_releases(api_client, app_name);
+    create_app_release(api_client, app_name);
+    rollback_app_release(api_client, app_name);
 
-    // create_app_setup(api_client);
-    // get_app_setup(api_client);
+    create_app_setup(api_client);
+    get_app_setup(api_client);
 
-    // create_app_sni(api_client, app_name);
-    // get_app_sni(api_client, app_name);
-    // get_app_sni_list(api_client, app_name);
-    // delete_app_sni(api_client, app_name);
-    // update_app_sni(api_client, app_name);
+    create_app_sni(api_client, app_name);
+    get_app_sni(api_client, app_name);
+    get_app_sni_list(api_client, app_name);
+    delete_app_sni(api_client, app_name);
+    update_app_sni(api_client, app_name);
 
-    // get_app_ssl_list(api_client, app_name);
-    // get_app_ssl(api_client, app_name);
-    // delete_app_ssl(api_client, app_name); // Careful here.
-    // create_app_ssl(api_client, app_name);
-    // update_app_ssl(api_client, app_name);
+    get_app_ssl_list(api_client, app_name);
+    get_app_ssl(api_client, app_name);
+    delete_app_ssl(api_client, app_name); // Careful here.
+    create_app_ssl(api_client, app_name);
+    update_app_ssl(api_client, app_name);
 }
 
 // get a specific webhook event
-fn get_app_webhook_event<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn get_app_webhook_event<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let event_id = "123";
-    let response = api_client.request(&apps::WebhookEventDetails::new(&app_id, event_id));
+    let response = api_client.request(&apps::WebhookEventDetails::new(app_id, event_id));
     print_response(response);
 }
 
 // get webhook events list
-fn get_app_webhook_events<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let response = api_client.request(&apps::WebhookEventList::new(&app_id));
+fn get_app_webhook_events<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let response = api_client.request(&apps::WebhookEventList::new(app_id));
     print_response(response);
 }
 
 // Update app SSL
-fn update_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn update_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let ssl_id = "123";
     // `new` method takes only the required parameters
-    let update_ssl = &apps::SSLUpdate::new(&app_id, ssl_id)
+    let update_ssl = &apps::SSLUpdate::new(app_id, ssl_id)
         .certificate_chain("chain_here")
         .private_key("key_here")
         .build();
@@ -117,12 +117,12 @@ fn update_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
 }
 
 // Create app SSL
-fn create_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn create_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let certificate_chain = "chain_here";
     let private_key = "key_here";
     // `new` method takes only the required parameters
     let response = api_client.request(&apps::SSLCreate::new(
-        &app_id,
+        app_id,
         certificate_chain,
         private_key,
     ));
@@ -130,32 +130,32 @@ fn create_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
 }
 
 // delete app SSL
-fn delete_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn delete_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let ssl_id = "123";
-    let response = api_client.request(&apps::SSLDelete::new(&app_id, ssl_id));
+    let response = api_client.request(&apps::SSLDelete::new(app_id, ssl_id));
     print_response(response);
 }
 
 // get app SSL
-fn get_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn get_app_ssl<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let ssl_id = "123";
-    let response = api_client.request(&apps::SSLDetails::new(&app_id, ssl_id));
+    let response = api_client.request(&apps::SSLDetails::new(app_id, ssl_id));
     print_response(response);
 }
 
 // get app SSL list
-fn get_app_ssl_list<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn get_app_ssl_list<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let response = api_client.request(&apps::SSLList::new(&app_id));
     print_response(response);
 }
 
 // update app SNI list
-fn update_app_sni<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn update_app_sni<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let certificate_chain = "chain_here";
     let private_key = "key_here";
     let sni_id = "123";
     let response = api_client.request(&apps::SNIUpdate::new(
-        &app_id,
+        app_id,
         sni_id,
         certificate_chain,
         private_key,
@@ -164,31 +164,31 @@ fn update_app_sni<T: HerokuApiClient>(api_client: &T, app_id: String) {
 }
 
 // delete app SNI list
-fn delete_app_sni<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn delete_app_sni<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let sni_id = "123";
-    let response = api_client.request(&apps::SNIDelete::new(&app_id, sni_id));
+    let response = api_client.request(&apps::SNIDelete::new(app_id, sni_id));
     print_response(response);
 }
 
 // get app SNI list
-fn get_app_sni_list<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let response = api_client.request(&apps::SNIList::new(&app_id));
+fn get_app_sni_list<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let response = api_client.request(&apps::SNIList::new(app_id));
     print_response(response);
 }
 
 // get app SNI
-fn get_app_sni<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn get_app_sni<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let sni_id = "123";
-    let response = api_client.request(&apps::SNIDetails::new(&app_id, sni_id));
+    let response = api_client.request(&apps::SNIDetails::new(app_id, sni_id));
     print_response(response);
 }
 
 // create app SNI
-fn create_app_sni<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn create_app_sni<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let certificate_chain = "chain_here";
     let private_key = "key_here";
     let response = api_client.request(&apps::SNICreate::new(
-        &app_id,
+        app_id,
         certificate_chain,
         private_key,
     ));
@@ -214,61 +214,57 @@ fn create_app_setup<T: HerokuApiClient>(api_client: &T) {
 }
 
 // get info about a slug
-fn get_slug<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let slug_id = String::from("SLUG_ID");
+fn get_slug<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let slug_id = "SLUG_ID";
     let response = api_client.request(&slugs::SlugDetails { app_id, slug_id });
     print_response(response);
 }
 
 /// create a slug
-fn create_slug<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn create_slug<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let mut process_types = HashMap::new();
-    process_types.insert("web".to_string(), "./bin/web -p $PORT".to_string());
+    process_types.insert("web", "./bin/web -p $PORT");
 
-    let response = api_client.request(&slugs::SlugCreate {
-        app_id,
-        params: slugs::SlugCreateParams {
-            process_types: process_types,
-            buildpack_provided_description: None,
-            checksum: None,
-            commit: None,
-            commit_description: None,
-            stack: None,
-        },
-    });
+    let response = api_client.request(
+        &slugs::SlugCreate::new(app_id, process_types)
+            .commit("60883d9e8947a57e04dc9124f25df004866a2051")
+            .commit_description("fixed a bug with API documentation")
+            .build(),
+    );
+
     print_response(response);
 }
 
 /// Stop dyno
-fn dyno_action_stop<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let domain_id = String::from("DYNO_ID_OR_NAME");
+fn dyno_action_stop<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let domain_id = "DYNO_ID_OR_NAME";
     let response = api_client.request(&domains::DomainDelete { app_id, domain_id });
     print_response(response);
 }
 
 /// Delete domain
-fn delete_app_domain<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let domain_id = String::from("DOMAIN_ID_OR_HOSTNAME");
+fn delete_app_domain<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let domain_id = "DOMAIN_ID_OR_HOSTNAME";
     let response = api_client.request(&domains::DomainDelete { app_id, domain_id });
     print_response(response);
 }
 
 /// Get domain
-fn get_app_domain<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let domain_id = String::from("DOMAIN_ID_OR_HOSTNAME");
+fn get_app_domain<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let domain_id = "DOMAIN_ID_OR_HOSTNAME";
     let response = api_client.request(&domains::DomainDetails { app_id, domain_id });
     print_response(response);
 }
 
 /// Get domains list
-fn get_app_domains<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn get_app_domains<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let response = api_client.request(&domains::DomainList { app_id });
     print_response(response);
 }
 
 /// Create domain
-fn create_app_domain<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let hostname = String::from("heroku-rs.tests.com");
+fn create_app_domain<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let hostname = "heroku-rs.tests.com";
     let response = api_client.request(&domains::DomainCreate {
         app_id,
         params: domains::DomainCreateParams { hostname },
@@ -277,8 +273,8 @@ fn create_app_domain<T: HerokuApiClient>(api_client: &T, app_id: String) {
 }
 
 /// Get a list of build pack installations
-fn get_buildpack_installations<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let response = api_client.request(&builds::BuildPackInstallationList::new(&app_id));
+fn get_buildpack_installations<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let response = api_client.request(&builds::BuildPackInstallationList::new(app_id));
     print_response(response);
 }
 
@@ -323,26 +319,23 @@ fn create_app_build<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, 
 }
 
 /// Gets a list of webhook deliveries.
-fn get_app_webhook_deliveries<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_name: String,
-) {
-    let response = api_client.request(&apps::AppWebhookDeliveryList { app_id: &app_name });
+fn get_app_webhook_deliveries<T: HerokuApiClient>(api_client: &T, app_name: &str) {
+    let response = api_client.request(&apps::AppWebhookDeliveryList { app_id: app_name });
     print_response(response);
 }
 
 /// Gets details about a specific webhook delivery.
-fn get_app_webhook_delivery<T: HerokuApiClient>(api_client: &T, app_name: String) {
+fn get_app_webhook_delivery<T: HerokuApiClient>(api_client: &T, app_name: &str) {
     let webhook_id = "WEBHOOK_DELIVERY_ID";
-    let response = api_client.request(&apps::AppWebhookDetails::new(&app_name, webhook_id));
+    let response = api_client.request(&apps::AppWebhookDetails::new(app_name, webhook_id));
 
     print_response(response);
 }
 
 /// Patch a specific webhook.
-fn patch_app_webhook<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
+fn patch_app_webhook<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
     let webhook_id = "WEBHOOK_ID";
-    let update_app_webhook = &apps::AppWebhookUpdate::new(&app_name, webhook_id)
+    let update_app_webhook = &apps::AppWebhookUpdate::new(app_name, webhook_id)
         .include(vec!["api:release"])
         .level("notify")
         .url("https://www.bing.com")
@@ -353,29 +346,29 @@ fn patch_app_webhook<ApiClientType: HerokuApiClient>(api_client: &ApiClientType,
 }
 
 /// Gets details about a specific webhook.
-fn get_app_webhook<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
+fn get_app_webhook<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
     let webhook_id = "WEBHOOK_ID";
-    let response = api_client.request(&apps::AppWebhookDetails::new(&app_name, webhook_id));
+    let response = api_client.request(&apps::AppWebhookDetails::new(app_name, webhook_id));
     print_response(response);
 }
 
 /// Gets a list of all webhooks that are available in the specified app.
-fn get_app_webhooks<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppWebhookList::new(&app_name));
+fn get_app_webhooks<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
+    let response = api_client.request(&apps::AppWebhookList::new(app_name));
     print_response(response);
 }
 
 /// Delete a specific app webhook by id
-fn delete_app_webhook<T: HerokuApiClient>(api_client: &T, app_name: String) {
+fn delete_app_webhook<T: HerokuApiClient>(api_client: &T, app_name: &str) {
     let webhook_id = "WEBHOOK_ID";
-    let response = api_client.request(&apps::AppWebhookDelete::new(&app_name, webhook_id));
+    let response = api_client.request(&apps::AppWebhookDelete::new(app_name, webhook_id));
     print_response(response);
 }
 
 /// Create a new app webhook
-fn create_app_webhook<T: HerokuApiClient>(api_client: &T, app_name: String) {
+fn create_app_webhook<T: HerokuApiClient>(api_client: &T, app_name: &str) {
     let webhook = &apps::AppWebhookCreate::new(
-        &app_name,
+        app_name,
         vec!["api:release"],
         "notify",
         "https://www.google.com",
@@ -385,42 +378,42 @@ fn create_app_webhook<T: HerokuApiClient>(api_client: &T, app_name: String) {
     print_response(response);
 }
 
-fn patch_app_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let update_feature = &apps::AppFeatureUpdate::new(&app_name, "spaces-dns-discovery", false);
+fn patch_app_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
+    let update_feature = &apps::AppFeatureUpdate::new(app_name, "spaces-dns-discovery", false);
     let response = api_client.request(update_feature);
     print_response(response);
 }
 
-fn get_app_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
+fn get_app_feature<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
     let response = api_client.request(&apps::AppFeatureDetails {
-        app_id: &app_name,
+        app_id: app_name,
         feature_id: "spaces-dns-discovery",
     });
     print_response(response);
 }
 
-fn get_app_features<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppFeatureList { app_id: &app_name });
+fn get_app_features<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
+    let response = api_client.request(&apps::AppFeatureList { app_id: app_name });
     print_response(response);
 }
 
-fn refresh_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppRefreshAcm::new(&app_name));
+fn refresh_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
+    let response = api_client.request(&apps::AppRefreshAcm::new(app_name));
     print_response(response);
 }
 
-fn disable_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
+fn disable_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
     let response = api_client.request(&apps::AppDisableAcm { app_id: &app_name });
     print_response(response);
 }
 
-fn enable_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    let response = api_client.request(&apps::AppEnableAcm::new(&app_name));
+fn enable_app_acm<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
+    let response = api_client.request(&apps::AppEnableAcm::new(app_name));
     print_response(response);
 }
 
-fn patch_app<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let patch = &apps::AppUpdate::new(&app_id)
+fn patch_app<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let patch = &apps::AppUpdate::new(app_id)
         .name("cool-name")
         .maintenance(false)
         .build();
@@ -428,28 +421,25 @@ fn patch_app<T: HerokuApiClient>(api_client: &T, app_id: String) {
     print_response(response);
 }
 
-fn delete_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let response = api_client.request(&apps::AppDelete::new(&app_id));
+fn delete_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
+    let response = api_client.request(&apps::AppDelete::new(app_id));
     print_response(response);
 }
 
-fn create_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let new_app = &apps::AppCreate::new().name(&app_id).build();
+fn create_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
+    let new_app = &apps::AppCreate::new().name(app_id).build();
     let response = api_client.request(new_app);
     print_response(response);
 }
 
-fn get_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let response = api_client.request(&apps::AppDetails::new(&app_id));
+fn get_app<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
+    let response = api_client.request(&apps::AppDetails::new(app_id));
     print_response(response);
 }
 
-fn get_app_raw_response<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_id: String,
-) {
+fn get_app_raw_response<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
     // If successful, this returns a raw reqwest::blocking::response, do whatever with it!
-    let response = api_client.request_raw(&apps::AppDetails::new(&app_id));
+    let response = api_client.request_raw(&apps::AppDetails::new(app_id));
     match response {
         Ok(res) => println!("Ok: {:?}", res),
         Err(e) => println!("Error: {}", e),
@@ -480,132 +470,101 @@ fn get_dyno_size_details<ApiClientType: HerokuApiClient>(api_client: &ApiClientT
     print_response(response);
 }
 
-fn get_dyno<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let dyno_id = String::from("web.1");
+fn get_dyno<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
+    let dyno_id = "web.1";
 
     let response = api_client.request(&dynos::DynoDetails { app_id, dyno_id });
     print_response(response);
 }
 
-fn list_dynos<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
+fn list_dynos<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
     let resp = api_client.request(&dynos::DynoList { app_id });
     print_response(resp);
 }
 
-fn create_dyno_simple<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let response = api_client.request(&dynos::DynoCreate {
-        app_id,
-        params: dynos::DynoCreateParams {
-            command: "bash".to_string(),
-            attach: None,
-            env: None,
-            force_no_tty: None,
-            size: None,
-            time_to_live: None,
-            r#type: None,
-        },
-    });
+fn create_dyno_simple<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
+    let response = api_client.request(&dynos::DynoCreate::new(app_id, "bash"));
 
     print_response(response);
 }
 
-fn create_dyno_complex<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
+fn create_dyno_complex<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
     let mut custom_env_vars = HashMap::new();
 
-    custom_env_vars.insert("COLUMNS".to_string(), "80".to_string());
+    custom_env_vars.insert("COLUMNS", "80");
 
-    custom_env_vars.insert("LINES".to_string(), "24".to_string());
+    custom_env_vars.insert("LINES", "24");
 
-    let response = api_client.request(&dynos::DynoCreate {
-        app_id: app_id,
-        params: dynos::DynoCreateParams {
-            command: "bash".to_string(),
-            attach: Some(true),
-            env: Some(custom_env_vars),
-            force_no_tty: None,
-            size: None,
-            time_to_live: None,
-            r#type: None,
-        },
-    });
+    let new_dyno_complex = &dynos::DynoCreate::new(app_id, "bash")
+        .attach(true)
+        .env(custom_env_vars)
+        .build();
+
+    let response = api_client.request(new_dyno_complex);
 
     print_response(response);
 }
 
 fn restart_dyno<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let app_id = String::from("heroku-rs-tests");
-    let dyno_id = String::from("web.1");
+    let app_id = "heroku-rs-tests";
+    let dyno_id = "web.1";
 
     let resp = api_client.request(&dynos::DynoRestart { app_id, dyno_id });
     print_response(resp);
 }
 
-fn restart_all_dynos<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
+fn restart_all_dynos<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
     let resp = api_client.request(&dynos::DynoAllRestart { app_id });
     print_response(resp);
 }
 
-fn list_app_formations<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
+fn list_app_formations<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
     let resp = api_client.request(&formations::FormationList { app_id });
     print_response(resp);
 }
 
-fn get_app_formation<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
+fn get_app_formation<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
     let resp = api_client.request(&formations::FormationDetails {
         app_id,
-        formation_id: "web".to_string(),
+        formation_id: "web",
     });
     print_response(resp);
 }
 
-fn update_app_formation<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_id: String,
-) {
-    let resp = api_client.request(&formations::FormationUpdate {
-        app_id: app_id,
-        formation_id: "web".to_string(),
-        params: formations::FormationUpdateParams {
-            quantity: Some(2),
-            size: Some("standard-1X".to_string()),
-        },
-    });
+fn update_app_formation<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
+    let resp = api_client.request(
+        &formations::FormationUpdate::new(app_id, "web")
+            .quantity(2)
+            .size("standard-1X")
+            .build(),
+    );
     print_response(resp);
 }
 
-fn list_app_releases<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
+fn list_app_releases<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let resp = api_client.request(&releases::ReleaseList { app_id });
     print_response(resp);
 }
 
-fn get_app_release<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_id: String,
-    release_id: String,
-) {
+fn get_app_release<T: HerokuApiClient>(api_client: &T, app_id: &str, release_id: &str) {
     let resp = api_client.request(&releases::ReleaseInfo { app_id, release_id });
     print_response(resp);
 }
 
-fn create_app_release<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: String) {
-    let resp = api_client.request(&releases::ReleaseCreate {
-        app_id,
-        params: releases::ReleaseCreateParams {
-            slug: "2dbce013-4be8-44e1-8221-c9c74e45949c".to_string(),
-            description: Some("added new feature".to_string()),
-        },
-    });
+fn create_app_release<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
+    let resp = api_client.request(
+        &releases::ReleaseCreate::new(app_id, "2dbce013-4be8-44e1-8221-c9c74e45949c")
+            .description("added new feature")
+            .build(),
+    );
     print_response(resp);
 }
 
-fn rollback_app_release<ApiClientType: HerokuApiClient>(
-    api_client: &ApiClientType,
-    app_id: String,
-) {
+fn rollback_app_release<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_id: &str) {
     let resp = api_client.request(&releases::ReleaseRollback {
         app_id,
         params: releases::ReleaseRollbackParams {
-            release: "v17".to_string(),
+            release: "v17",
         },
     });
     print_response(resp);

--- a/examples/src/apps_examples.rs
+++ b/examples/src/apps_examples.rs
@@ -278,27 +278,14 @@ fn create_app_domain<T: HerokuApiClient>(api_client: &T, app_id: String) {
 
 /// Get a list of build pack installations
 fn get_buildpack_installations<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let response = api_client.request(&builds::BuildPackInstallationList { app_id });
+    let response = api_client.request(&builds::BuildPackInstallationList::new(&app_id));
     print_response(response);
 }
 
 /// Update build pack installations
-fn update_buildpack_installation<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let buildpack_ruby = String::from("https://github.com/heroku/heroku-buildpack-ruby");
-    let buildpack_python = String::from("https://github.com/heroku/heroku-buildpack-python");
-    // let updates = vec![
-    //     builds::Update {
-    //         buildpack: buildpack_ruby,
-    //     },
-    //     builds::Update {
-    //         buildpack: buildpack_python,
-    //     },
-    // ];
-
-    // let response = api_client.request(&builds::BuildpackInstallationUpdate {
-    //     app_id,
-    //     params: builds::BuildpackInstallationUpdateParams { updates },
-    // });
+fn update_buildpack_installation<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let buildpack_ruby = "https://github.com/heroku/heroku-buildpack-ruby";
+    let buildpack_python = "https://github.com/heroku/heroku-buildpack-python";
 
     let builpack_list = vec![buildpack_ruby, buildpack_python];
     let response = api_client.request(&builds::BuildpackInstallationUpdate::new(
@@ -309,44 +296,29 @@ fn update_buildpack_installation<T: HerokuApiClient>(api_client: &T, app_id: Str
 }
 
 /// Delete build cache
-fn delete_app_build<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn delete_app_build<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let response = api_client.request(&builds::BuildDelete { app_id });
     print_response(response);
 }
 
 /// Gets info about a specific build
-fn get_app_build<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let build_id = String::from("Build_ID");
+fn get_app_build<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let build_id = "Build_ID";
     let response = api_client.request(&builds::BuildDetails { app_id, build_id });
     print_response(response);
 }
 
 /// Gets a list of builds
-fn get_app_builds<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn get_app_builds<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let response = api_client.request(&builds::BuildList { app_id });
     print_response(response);
 }
 
 /// Create a new build
-fn create_app_build<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: String) {
-    // let response = api_client.request(&builds::BuildCreate {
-    //     app_id: app_name,
-    //     params: builds::BuildCreateParams {
-    //         buildpacks: None,
-    //         source_blob: builds::SourceBlobParam {
-    //             checksum: Some(String::from(
-    //                 "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    //             )),
-    //             url: String::from("https://example.com/source.tgz?token=xyz"),
-    //             version: Some(String::from("2")),
-    //         },
-    //     },
-    // });
-
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let url = String::from("https://example.com/source.tgz?token=xyz");
-    let response = api_client.request(&builds::BuildCreate::create(app_name, url));
+fn create_app_build<ApiClientType: HerokuApiClient>(api_client: &ApiClientType, app_name: &str) {
+    // `new` method takes only the required parameters
+    let blob_url = "https://example.com/source.tgz?token=xyz";
+    let response = api_client.request(&builds::BuildCreate::new(app_name, blob_url));
     print_response(response);
 }
 

--- a/examples/src/collaborators_examples.rs
+++ b/examples/src/collaborators_examples.rs
@@ -4,7 +4,7 @@ use heroku_rs::endpoints::collaborators;
 use heroku_rs::framework::apiclient::HerokuApiClient;
 
 pub fn run<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
-    let app_name = String::from("heroku-rs-tests");
+    let app_name = "heroku-rs-tests";
 
     // create_app_collaborate(api_client, app_name);
     get_app_collaborators(api_client, app_name);
@@ -63,35 +63,19 @@ fn get_team_app_collaborators<T: HerokuApiClient>(api_client: &T, app_id: &str) 
 /// Create team app collaborator
 fn create_team_app_collaborator<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let user = "EMAIL_or_ID_HERE";
-    let silent = Some(false);
-    let permissions = Some(vec!["view"]);
-    //The old way of creating a request, still works
-    // let response = api_client.request(&collaborators::TeamCollaboratorCreate {
-    //     app_id,
-    //     params: collaborators::TeamCollaboratorCreateParams {
-    //         user,
-    //         silent,
-    //         permissions,
-    //     },
-    // });
-
+    let team_app_collab = &collaborators::TeamCollaboratorCreate::new(app_id, user)
+        .permissions(vec!["view"])
+        .silent(false)
+        .build();
     //New way to create a request where you can pass optional parameters
-    let response = api_client.request(&collaborators::TeamCollaboratorCreate::new(
-        app_id,
-        user,
-        silent,
-        permissions,
-    ));
-
-    //New way to create a request where you can pass only the required parameters
-    // let response = api_client.request(&collaborators::TeamCollaboratorCreate::create(app_id, user));
+    let response = api_client.request(team_app_collab);
 
     print_response(response);
 }
 
 /// Delete app collaborator
-fn delete_app_collaborator<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let collaborator_id = String::from("COLLAB_EMAIL_OR_ID");
+fn delete_app_collaborator<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let collaborator_id = "COLLAB_EMAIL_OR_ID";
     let response = api_client.request(&collaborators::CollaboratorDelete {
         app_id,
         collaborator_id,
@@ -100,8 +84,8 @@ fn delete_app_collaborator<T: HerokuApiClient>(api_client: &T, app_id: String) {
 }
 
 /// Get app collaborator
-fn get_app_collaborator<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let collaborator_id = String::from("COLLAB_EMAIL_OR_ID");
+fn get_app_collaborator<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let collaborator_id = "COLLAB_EMAIL_OR_ID";
     let response = api_client.request(&collaborators::CollaboratorDetails {
         app_id,
         collaborator_id,
@@ -110,18 +94,17 @@ fn get_app_collaborator<T: HerokuApiClient>(api_client: &T, app_id: String) {
 }
 
 /// Get a list of app collaborators
-fn get_app_collaborators<T: HerokuApiClient>(api_client: &T, app_id: String) {
+fn get_app_collaborators<T: HerokuApiClient>(api_client: &T, app_id: &str) {
     let response = api_client.request(&collaborators::CollaboratorList { app_id });
     print_response(response);
 }
 
 /// Create app collaborator
-fn create_app_collaborate<T: HerokuApiClient>(api_client: &T, app_id: String) {
-    let user = String::from("EMAIL_or_ID_HERE");
-    let silent = Some(false);
-    let response = api_client.request(&collaborators::CollaboratorCreate {
-        app_id,
-        params: collaborators::CollaboratorCreateParams { user, silent },
-    });
+fn create_app_collaborate<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let user = "EMAIL_or_ID_HERE";
+    let app_collaborator = &collaborators::CollaboratorCreate::new(app_id, user)
+        .silent(false)
+        .build();
+    let response = api_client.request(app_collaborator);
     print_response(response);
 }

--- a/examples/src/logs_examples.rs
+++ b/examples/src/logs_examples.rs
@@ -18,9 +18,8 @@ pub fn run<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
 
 // creat log session
 fn create_log_session<T: HerokuApiClient>(api_client: &T, app_id: &str) {
-    // `create` method takes only the required parameters
-    // see `new` to pass optional parameters too
-    let response = api_client.request(&logs::LogSessionCreate::create(app_id));
+    // `new` method takes only the required parameters
+    let response = api_client.request(&logs::LogSessionCreate::new(app_id).tail(false).build());
     print_response(response);
 }
 

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // see the create_custom_client and uncomment this to use it
     // let api_client = create_custom_client(token)?;
 
-    // apps_examples::run(&api_client);
+    apps_examples::run(&api_client);
     // addon_examples::run(&api_client);
     // collaborators_examples::run(&api_client);
     // logs_examples::run(&api_client);
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // pipeline_examples::run(&api_client);
     // misc_examples::run(&api_client);
     // teams_examples::run(&api_client);
-    spaces_examples::run(&api_client);
+    // spaces_examples::run(&api_client);
 
     Ok(())
 }

--- a/examples/src/misc_examples.rs
+++ b/examples/src/misc_examples.rs
@@ -23,7 +23,7 @@ fn create_sources<T: HerokuApiClient>(api_client: &T) {
 
 /// Get a specific stack
 fn get_stack<T: HerokuApiClient>(api_client: &T) {
-    let stack_id = String::from("69bee368-352b-4bd0-9b7c-819d860a2588"); // heroku-18 stack
+    let stack_id = "69bee368-352b-4bd0-9b7c-819d860a2588"; // heroku-18 stack
     let response = api_client.request(&misc::StackDetails { stack_id });
     print_response(response);
 }
@@ -48,7 +48,7 @@ fn get_regions<T: HerokuApiClient>(api_client: &T) {
 
 /// Get specific region
 fn get_region<T: HerokuApiClient>(api_client: &T) {
-    let region_id = String::from("6f2b2ec9-b087-4976-8ec9-5d2f62276aeb"); // Dublin - Ireland
+    let region_id = "6f2b2ec9-b087-4976-8ec9-5d2f62276aeb"; // Dublin - Ireland
     let response = api_client.request(&misc::RegionDetails { region_id });
     print_response(response);
 }

--- a/examples/src/oauth_examples.rs
+++ b/examples/src/oauth_examples.rs
@@ -23,7 +23,7 @@ pub fn run<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
 
 // delete client
 fn delete_oauth_token<T: HerokuApiClient>(api_client: &T) {
-    let token_id = String::from("TOKEN_ID");
+    let token_id = "TOKEN_ID";
     let response = api_client.request(&oauth::OAuthTokenDelete { token_id });
     print_response(response);
 }
@@ -31,51 +31,44 @@ fn delete_oauth_token<T: HerokuApiClient>(api_client: &T) {
 // create auth token
 // these are dummy uuid / data
 fn create_oauth_token<T: HerokuApiClient>(api_client: &T) {
-    let client = oauth::post::Client {
-        secret: String::from("01234567-89ab-cdef-0123-456789abcdef"),
-    };
-    let grant = oauth::post::Grant {
-        code: String::from("01234567-89ab-cdef-0123-456789abcdef"),
-        type_field: String::from("authorization_code"),
-    };
+    let client_secret = "01234567-89ab-cdef-0123-456789abcdef";
+    let grant_code = "01234567-89ab-cdef-0123-456789abcdef";
+    let grant_type = "authorization_code";
+    let refresh_token = "01234567-89ab-cdef-0123-456789abcdef";
 
-    let refresh_token = oauth::post::RefreshToken {
-        token: String::from("01234567-89ab-cdef-0123-456789abcdef"),
-    };
-
-    let response = api_client.request(&oauth::OAuthTokenCreate {
-        params: oauth::OAuthTokenCreateParams {
-            client,
-            grant,
-            refresh_token,
-        },
-    });
+    let response = api_client.request(&oauth::OAuthTokenCreate::new(
+        client_secret,
+        grant_code,
+        grant_type,
+        refresh_token,
+    ));
     print_response(response);
 }
 
 // delete client
 fn delete_client<T: HerokuApiClient>(api_client: &T) {
-    let client_id = String::from("CLIENT_ID");
+    let client_id = "CLIENT_ID";
     let response = api_client.request(&oauth::OAuthClientDelete { client_id });
     print_response(response);
 }
 
 // rotate client credentials
 fn rotate_client_credentials<T: HerokuApiClient>(api_client: &T) {
-    let client_id = String::from("CLIENT_ID");
+    let client_id = "CLIENT_ID";
     let response = api_client.request(&oauth::OAuthClientRotateCredentials { client_id });
     print_response(response);
 }
 
 // update auth client
 fn patch_oauth_client<T: HerokuApiClient>(api_client: &T) {
-    let name = String::from("Client Name Son!");
-    let client_id = String::from("CLIENT_ID");
-    let redirect_uri = String::from("https://www.blog.redirecting_site_here.dev");
-    let response = api_client.request(&oauth::OAuthClientUpdate {
-        client_id,
-        params: oauth::OAuthClientUpdateParams { name, redirect_uri },
-    });
+    let client_id = "CLIENT_ID";
+    let redirect_uri = "https://www.blog.redirecting_site_here.dev";
+    let response = api_client.request(
+        &oauth::OAuthClientUpdate::new(client_id)
+            .name("CLIENT NAME")
+            .redirect_uri(redirect_uri)
+            .build(),
+    );
     print_response(response);
 }
 
@@ -87,15 +80,15 @@ fn get_oauth_clients<T: HerokuApiClient>(api_client: &T) {
 
 // get client with id
 fn get_oauth_client<T: HerokuApiClient>(api_client: &T) {
-    let client_id = String::from("CLIENT_ID");
+    let client_id = "CLIENT_ID";
     let response = api_client.request(&oauth::OAuthClientDetails { client_id });
     print_response(response);
 }
 
 // create a auth client
 fn create_oauth_client<T: HerokuApiClient>(api_client: &T) {
-    let name = String::from("Client Name");
-    let redirect_uri = String::from("https://www.redirecting_site_here.dev");
+    let name = "Client Name";
+    let redirect_uri = "https://www.redirecting_site_here.dev";
     let response = api_client.request(&oauth::OAuthClientCreate {
         params: oauth::OAuthClientCreateParams { name, redirect_uri },
     });
@@ -104,35 +97,32 @@ fn create_oauth_client<T: HerokuApiClient>(api_client: &T) {
 
 // delete specific oauth token
 fn delete_oauth<T: HerokuApiClient>(api_client: &T) {
-    let oauth_id = String::from("OAUTH_ID");
+    let oauth_id = "OAUTH_ID";
     let response = api_client.request(&oauth::OAuthDelete { oauth_id });
     print_response(response);
 }
 
 // regenerate specific oauth token
 fn regenerate_oauth<T: HerokuApiClient>(api_client: &T) {
-    let oauth_id = String::from("OAUTH_ID");
+    let oauth_id = "OAUTH_ID";
     let response = api_client.request(&oauth::OAuthRegenerate { oauth_id });
     print_response(response);
 }
 
 // create auth token
 fn create_oauth<T: HerokuApiClient>(api_client: &T) {
-    let auth_scope = vec!["global".to_owned()];
-    let response = api_client.request(&oauth::OAuthCreate {
-        params: oauth::OAuthCreateParams {
-            scope: auth_scope,
-            client: None,
-            description: None,
-            expires_in: None,
-        },
-    });
+    let auth_scope = vec!["global"];
+    let response = api_client.request(
+        &oauth::OAuthCreate::new(auth_scope)
+            .description("Global oauth token")
+            .build(),
+    );
     print_response(response);
 }
 
 // get specific oauth info
 fn get_oauth_info<T: HerokuApiClient>(api_client: &T) {
-    let oauth_id = String::from("OAUTH_ID");
+    let oauth_id = "OAUTH_ID";
     let response = api_client.request(&oauth::OAuthDetails { oauth_id });
     print_response(response);
 }

--- a/examples/src/pipeline_examples.rs
+++ b/examples/src/pipeline_examples.rs
@@ -35,110 +35,105 @@ pub fn run<ApiClientType: HerokuApiClient>(api_client: &ApiClientType) {
 
 // create pipeline transfer
 fn create_pipeline_transfer<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
-    let owner_type = String::from("user");
-    let new_owner_id = String::from("OWNER_ID");
-    let response = api_client.request(&pipelines::PipelineTransferCreate {
-        params: pipelines::PipelineTransferCreateParams::new(pipeline_id, new_owner_id, owner_type),
-    });
+    let pipeline_id = "PIPELINE_ID";
+    let owner_type = "user";
+    let new_owner_id = "OWNER_ID";
+    let response = api_client.request(&pipelines::PipelineTransferCreate::new(
+        pipeline_id,
+        new_owner_id,
+        owner_type,
+    ));
     print_response(response);
 }
 
 // get pipline stack
 fn get_pipeline_stack<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelineStackDetails { pipeline_id });
     print_response(response);
 }
 
 // get pipline release
 fn get_pipeline_releases<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelineLatestReleaseList { pipeline_id });
     print_response(response);
 }
 
 // get pipline promotion target list
 fn get_pipeline_promotion_target_list<T: HerokuApiClient>(api_client: &T) {
-    let promotion_id = String::from("PIPELINE_ID");
+    let promotion_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelinePromotionTargetList { promotion_id });
     print_response(response);
 }
 
 // get pipline promotion
 fn get_pipeline_promotion<T: HerokuApiClient>(api_client: &T) {
-    let promotion_id = String::from("PIPELINE_ID");
+    let promotion_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelinePromotionDetails { promotion_id });
     print_response(response);
 }
 
 // create pipeline promotion
 fn create_pipeline_promotion<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
-    let source_app_id = String::from("SOURCE_APP_ID");
-    let target_app_id = String::from("TARGET_APP_ID");
-    let response = api_client.request(&pipelines::PipelinePromotionCreate {
-        params: pipelines::PipelinePromotionCreateParams::new(
-            pipeline_id,
-            source_app_id,
-            target_app_id,
-        ),
-    });
+    let pipeline_id = "PIPELINE_ID";
+    let source_app_id = "SOURCE_APP_ID";
+    let target_app_id = "TARGET_APP_ID";
+    let response = api_client.request(&pipelines::PipelinePromotionCreate::new(
+        pipeline_id,
+        source_app_id,
+        target_app_id,
+    ));
     print_response(response);
 }
 
 // get pipline deployments
 fn get_pipline_deployments<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelineDeploymentList { pipeline_id });
     print_response(response);
 }
 
 // delete pipeline coupling
 fn delete_pipeline_coupling<T: HerokuApiClient>(api_client: &T) {
-    let coupling_id = String::from("COUPLING_ID");
+    let coupling_id = "COUPLING_ID";
     let response = api_client.request(&pipelines::PipelineCouplingDelete { coupling_id });
     print_response(response);
 }
 
 // get app pipeline coupling details
 fn get_app_pipeline_coupling<T: HerokuApiClient>(api_client: &T) {
-    let app_id = String::from("APP_ID");
+    let app_id = "APP_ID";
     let response = api_client.request(&pipelines::PipelineCouplingByAppDetails { app_id });
     print_response(response);
 }
 
 // update pipeline coupling
 fn update_pipeline_coupling<T: HerokuApiClient>(api_client: &T) {
-    let coupling_id = String::from("COUPLING_ID");
-    let response = api_client.request(&pipelines::PipelineCouplingUpdate {
-        coupling_id,
-        params: pipelines::PipelineCouplingUpdateParams {
-            stage: String::from("development"),
-        },
-    });
+    let coupling_id = "COUPLING_ID";
+    let response = api_client.request(
+        &pipelines::PipelineCouplingUpdate::new(coupling_id)
+            .stage("development")
+            .build(),
+    );
     print_response(response);
 }
 
 // get pipeline coupling details
 fn get_pipeline_coupling<T: HerokuApiClient>(api_client: &T) {
-    let coupling_id = String::from("COUPLING_ID");
+    let coupling_id = "COUPLING_ID";
     let response = api_client.request(&pipelines::PipelineCouplingDetails { coupling_id });
     print_response(response);
 }
 
 // craete pipeline coupling
 fn create_pipeline_coupling<T: HerokuApiClient>(api_client: &T) {
-    let app = String::from("APP_ID"); // can be app name or app id
-    let pipeline = String::from("PIPELINE_ID"); // pipeline id
-    let stage = String::from("test");
-    let response = api_client.request(&pipelines::PipelineCouplingCreate {
-        params: pipelines::PipelineCouplingCreateParams {
-            app,
-            pipeline,
-            stage,
-        },
-    });
+    let app = "APP_ID"; // can be app name or app id
+    let pipeline = "PIPELINE_ID"; // pipeline id
+    let stage = "test";
+    let response = api_client.request(&pipelines::PipelineCouplingCreate::new(
+        app, pipeline, stage,
+    ));
     print_response(response);
 }
 
@@ -150,7 +145,7 @@ fn get_pipeline_couplings<T: HerokuApiClient>(api_client: &T) {
 
 // get team pipeline couplings
 fn get_team_pipeline_couplings<T: HerokuApiClient>(api_client: &T) {
-    let team_id = String::from("TEAM_ID");
+    let team_id = "TEAM_ID";
     let response = api_client.request(&pipelines::PipelineCouplingByTeamList { team_id });
     print_response(response);
 }
@@ -163,39 +158,39 @@ fn get_user_pipeline_couplings<T: HerokuApiClient>(api_client: &T) {
 
 // get pipeline couplings by pipeline id
 fn get_pipeline_pipeline_couplings<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelineCouplingByPipelineList { pipeline_id });
     print_response(response);
 }
 
 // get pipeline latest builds
 fn get_pipeline_latest_builds<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelineLatestBuildsList { pipeline_id });
     print_response(response);
 }
 
 // delete pipeline
 fn delete_pipeline<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelineDelete { pipeline_id });
     print_response(response);
 }
 
 // update pipeline
 fn update_pipeline<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
-    let name = String::from("my-renamed-pipe");
-    let response = api_client.request(&pipelines::PipelineUpdate {
-        pipeline_id,
-        params: pipelines::PipelineUpdateParams { name: Some(name) },
-    });
+    let pipeline_id = "PIPELINE_ID";
+    let response = api_client.request(
+        &pipelines::PipelineUpdate::new(pipeline_id)
+            .name("my-renamed-pipe")
+            .build(),
+    );
     print_response(response);
 }
 
 // get pipeline info
 fn get_pipeline<T: HerokuApiClient>(api_client: &T) {
-    let pipeline_id = String::from("PIPELINE_ID");
+    let pipeline_id = "PIPELINE_ID";
     let response = api_client.request(&pipelines::PipelineDetails { pipeline_id });
     print_response(response);
 }
@@ -208,10 +203,6 @@ fn get_pipelines<T: HerokuApiClient>(api_client: &T) {
 
 // create a new pipeline
 fn create_pipeline<T: HerokuApiClient>(api_client: &T) {
-    let response = api_client.request(&pipelines::PipelineCreate {
-        params: pipelines::PipelineCreateParams {
-            name: String::from("my-pipe"),
-        },
-    });
+    let response = api_client.request(&pipelines::PipelineCreate::new("my-pipe"));
     print_response(response);
 }

--- a/examples/src/teams_examples.rs
+++ b/examples/src/teams_examples.rs
@@ -46,8 +46,11 @@ pub fn run<T: HerokuApiClient>(api_client: &T) {
 // update team preferences
 fn update_team_preferences<T: HerokuApiClient>(api_client: &T) {
     let id = "123";
-    let whitelist_enabled = Some(true);
-    let response = api_client.request(&teams::TeamPreferenceUpdate::new(id, whitelist_enabled));
+    let response = api_client.request(
+        &teams::TeamPreferenceUpdate::new(id)
+            .whitelisting_enabled(true)
+            .build(),
+    );
     print_response(response);
 }
 
@@ -86,7 +89,11 @@ fn team_member_update<T: HerokuApiClient>(api_client: &T) {
     let email = "123@example.de";
     let role = "admin";
     let team_id = "123";
-    let response = api_client.request(&teams::TeamMemberUpdate::create(team_id, email, role));
+    let response = api_client.request(
+        &teams::TeamMemberUpdate::new(team_id, email, role)
+            .federated(false)
+            .build(),
+    );
     print_response(response);
 }
 
@@ -95,7 +102,7 @@ fn team_member_create<T: HerokuApiClient>(api_client: &T) {
     let email = "123@example.de";
     let role = "admin";
     let team_id = "123";
-    let response = api_client.request(&teams::TeamMemberCreate::create(team_id, email, role));
+    let response = api_client.request(&teams::TeamMemberCreate::new(team_id, email, role));
     print_response(response);
 }
 
@@ -104,9 +111,7 @@ fn team_member_create_or_update<T: HerokuApiClient>(api_client: &T) {
     let email = "123@example.de";
     let role = "admin";
     let team_id = "123";
-    let response = api_client.request(&teams::TeamMemberCreateorUpdate::create(
-        team_id, email, role,
-    ));
+    let response = api_client.request(&teams::TeamMemberCreateorUpdate::new(team_id, email, role));
     print_response(response);
 }
 
@@ -154,9 +159,11 @@ fn revoke_team_invitation<T: HerokuApiClient>(api_client: &T) {
 fn create_team_invitation<T: HerokuApiClient>(api_client: &T) {
     let team_id = "123";
     let email = "name@gmail.com";
-    // this will send a `null` to the API
-    let role = None;
-    let response = api_client.request(&teams::TeamInvitationCreate::new(team_id, email, role));
+    let response = api_client.request(
+        &teams::TeamInvitationCreate::new(team_id, email)
+            .role("member")
+            .build(),
+    );
     print_response(response);
 }
 
@@ -228,12 +235,12 @@ fn update_team_app<T: HerokuApiClient>(api_client: &T) {
 /// Create a new team app
 fn update_team<T: HerokuApiClient>(api_client: &T) {
     let team_id = "123";
-    // let response = api_client.request(&teams::TeamUpdate {
-    //     team_id,
-    //     params_optional: None,
-    // });
-
-    let response = api_client.request(&teams::TeamUpdate::new(team_id, None, None));
+    let response = api_client.request(
+        &teams::TeamUpdate::new(team_id)
+            .default(false)
+            .name("new-team-name")
+            .build(),
+    );
     print_response(response);
 }
 
@@ -246,8 +253,12 @@ fn get_team_app<T: HerokuApiClient>(api_client: &T) {
 
 /// Create a new team app
 fn create_team_app<T: HerokuApiClient>(api_client: &T) {
-    // let response = api_client.request(&teams::TeamAppCreate { params: None });
-    let response = api_client.request(&teams::TeamAppCreate::create());
+    let response = api_client.request(
+        &teams::TeamAppCreate::new()
+            .name("team-app")
+            .locked(true)
+            .build(),
+    );
     print_response(response);
 }
 
@@ -279,37 +290,11 @@ fn get_team<T: HerokuApiClient>(api_client: &T) {
 }
 
 /// Create a new team
-/// Parameters specified with None will not be sent
 fn create_team<T: HerokuApiClient>(api_client: &T) {
-    // team name
-    let name = "herokursteam2020";
 
-    // let response = api_client.request(&teams::TeamCreate {
-    //     params: teams::TeamCreateParams {
-    //         name: name,
-    //         params_optional: Some(teams::TeamCreateOptionalParams {
-    //             address_1: None,
-    //             address_2: Some("test"),
-    //             card_number: None,
-    //             city: None,
-    //             country: None,
-    //             cvv: None,
-    //             expiration_month: None,
-    //             expiration_year: None,
-    //             first_name: None,
-    //             last_name: None,
-    //             other: None,
-    //             postal_code: None,
-    //             state: None,
-    //             nonce: None,
-    //             device_data: None,
-    //         }),
-    //     },
-    // });
-
-    // `create` method has only the required parameters
-    // use `new` method if you want to pass optional parameters
-    let response = api_client.request(&teams::TeamCreate::create(name));
+    // `new` method takes only the required parameters and gives access to the builder pattern
+    //address_2 is optional, but showcasing builder pattern
+    let response = api_client.request(&teams::TeamCreate::new("herokursteam2020").address_2("test").build());
     print_response(response);
 }
 

--- a/src/endpoints/account/delete.rs
+++ b/src/endpoints/account/delete.rs
@@ -30,18 +30,18 @@ impl HerokuEndpoint<Account> for AccountDelete {
 /// Delete user account. Note that this action cannot be undone.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#account-delete-by-user)
-pub struct UserAccountDelete {
+pub struct UserAccountDelete<'a> {
     /// account_id can be the account email or id.
-    pub account_id: String,
+    pub account_id: &'a str,
 }
 
-impl UserAccountDelete {
-    pub fn new(account_id: String) -> UserAccountDelete {
+impl<'a> UserAccountDelete<'a> {
+    pub fn new(account_id: &'a str) -> UserAccountDelete<'a> {
         UserAccountDelete { account_id }
     }
 }
 
-impl HerokuEndpoint<Account> for UserAccountDelete {
+impl<'a> HerokuEndpoint<Account> for UserAccountDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }
@@ -55,18 +55,18 @@ impl HerokuEndpoint<Account> for UserAccountDelete {
 /// Delete an existing app transfer
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-transfer-delete)
-pub struct AppTransferDelete {
+pub struct AppTransferDelete<'a> {
     /// transfer_id can be the transfer name or id.
-    pub transfer_id: String,
+    pub transfer_id: &'a str,
 }
 
-impl AppTransferDelete {
-    pub fn new(transfer_id: String) -> AppTransferDelete {
+impl<'a> AppTransferDelete<'a> {
+    pub fn new(transfer_id: &'a str) -> AppTransferDelete {
         AppTransferDelete { transfer_id }
     }
 }
 
-impl HerokuEndpoint<Account> for AppTransferDelete {
+impl<'a> HerokuEndpoint<Account> for AppTransferDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/account/get.rs
+++ b/src/endpoints/account/get.rs
@@ -32,18 +32,18 @@ impl HerokuEndpoint<Account> for AccountDetails {
 /// Info for account.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference##account-info-by-user)
-pub struct UserAccountDetails {
+pub struct UserAccountDetails<'a> {
     /// account_id can be the account email or id.
-    pub account_id: String,
+    pub account_id: &'a str,
 }
 
-impl UserAccountDetails {
-    pub fn new(account_id: String) -> UserAccountDetails {
+impl<'a> UserAccountDetails<'a> {
+    pub fn new(account_id: &'a str) -> UserAccountDetails {
         UserAccountDetails { account_id }
     }
 }
 
-impl HerokuEndpoint<Account> for UserAccountDetails {
+impl<'a> HerokuEndpoint<Account> for UserAccountDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -79,18 +79,18 @@ impl HerokuEndpoint<Vec<AccountFeature>> for AccountFeatureList {
 /// Info for an existing account feature.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#account-feature-info)
-pub struct AccountFeatureDetails {
+pub struct AccountFeatureDetails<'a> {
     /// feature_id can be the feature name or id.
-    pub feature_id: String,
+    pub feature_id: &'a str,
 }
 
-impl AccountFeatureDetails {
-    pub fn new(feature_id: String) -> AccountFeatureDetails {
+impl<'a> AccountFeatureDetails<'a> {
+    pub fn new(feature_id: &'a str) -> AccountFeatureDetails {
         AccountFeatureDetails { feature_id }
     }
 }
 
-impl HerokuEndpoint<AccountFeature> for AccountFeatureDetails {
+impl<'a> HerokuEndpoint<AccountFeature> for AccountFeatureDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -126,18 +126,18 @@ impl HerokuEndpoint<Vec<AppTransfer>> for AppTransferList {
 /// Info for existing app transfer.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-transfer-info)
-pub struct AppTransferDetails {
+pub struct AppTransferDetails<'a> {
     /// transfer_id can be the transfer name or id.
-    pub transfer_id: String,
+    pub transfer_id: &'a str,
 }
 
-impl AppTransferDetails {
-    pub fn new(transfer_id: String) -> AppTransferDetails {
+impl<'a> AppTransferDetails<'a> {
+    pub fn new(transfer_id: &'a str) -> AppTransferDetails {
         AppTransferDetails { transfer_id }
     }
 }
 
-impl HerokuEndpoint<AppTransfer> for AppTransferDetails {
+impl<'a> HerokuEndpoint<AppTransfer> for AppTransferDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -151,18 +151,18 @@ impl HerokuEndpoint<AppTransfer> for AppTransferDetails {
 /// Info for existing credit.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#credit-info)
-pub struct AccountCreditDetails {
+pub struct AccountCreditDetails<'a> {
     /// credit_id is the credit identifier.
-    pub credit_id: String,
+    pub credit_id: &'a str,
 }
 
-impl AccountCreditDetails {
-    pub fn new(credit_id: String) -> AccountCreditDetails {
+impl<'a> AccountCreditDetails<'a> {
+    pub fn new(credit_id: &'a str) -> AccountCreditDetails {
         AccountCreditDetails { credit_id }
     }
 }
 
-impl HerokuEndpoint<AppTransfer> for AccountCreditDetails {
+impl<'a> HerokuEndpoint<AppTransfer> for AccountCreditDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/account/patch.rs
+++ b/src/endpoints/account/patch.rs
@@ -8,31 +8,43 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Update account.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#account-update)
-pub struct AccountUpdate {
-    pub params: AccountUpdateParams,
+pub struct AccountUpdate<'a> {
+    /// The parameters to pass to the Heroku API
+    pub params: AccountUpdateParams<'a>,
 }
 
-impl AccountUpdate {
-    pub fn new(
-        allow_tracking: Option<bool>,
-        beta: Option<bool>,
-        name: Option<String>,
-    ) -> AccountUpdate {
-        AccountUpdate {
-            params: AccountUpdateParams {
-                allow_tracking,
-                beta,
-                name,
-            },
-        }
-    }
-
-    pub fn create() -> AccountUpdate {
+impl<'a> AccountUpdate<'a> {
+    pub fn new() -> AccountUpdate<'a> {
         AccountUpdate {
             params: AccountUpdateParams {
                 allow_tracking: None,
                 beta: None,
                 name: None,
+            },
+        }
+    }
+
+    pub fn allow_tracking(&mut self, allow_tracking: bool) -> &mut Self {
+        self.params.allow_tracking = Some(allow_tracking);
+        self
+    }
+
+    pub fn beta(&mut self, beta: bool) -> &mut Self {
+        self.params.beta = Some(beta);
+        self
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn build(&self) -> AccountUpdate<'a> {
+        AccountUpdate {
+            params: AccountUpdateParams {
+                allow_tracking: self.params.allow_tracking,
+                beta: self.params.beta,
+                name: self.params.name,
             },
         }
     }
@@ -44,7 +56,7 @@ impl AccountUpdate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#account-update-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct AccountUpdateParams {
+pub struct AccountUpdateParams<'a> {
     /// whether to allow third party web activity tracking, by default: true
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_tracking: Option<bool>,
@@ -52,17 +64,17 @@ pub struct AccountUpdateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub beta: Option<bool>,
     /// full name of the account owner [Nullable]
-    pub name: Option<String>,
+    pub name: Option<&'a str>,
 }
 
-impl HerokuEndpoint<Account, (), AccountUpdateParams> for AccountUpdate {
+impl<'a> HerokuEndpoint<Account, (), AccountUpdateParams<'a>> for AccountUpdate<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("account",)
     }
-    fn body(&self) -> Option<AccountUpdateParams> {
+    fn body(&self) -> Option<AccountUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -72,37 +84,47 @@ impl HerokuEndpoint<Account, (), AccountUpdateParams> for AccountUpdate {
 /// Update account.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#account-update-by-user)
-pub struct UserAccountUpdate {
+pub struct UserAccountUpdate<'a> {
     /// account_id can be the account email or id.
-    pub account_id: String,
+    pub account_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: UserAccountUpdateParams,
+    pub params: UserAccountUpdateParams<'a>,
 }
 
-impl UserAccountUpdate {
-    pub fn new(
-        account_id: String,
-        allow_tracking: Option<bool>,
-        beta: Option<bool>,
-        name: Option<String>,
-    ) -> UserAccountUpdate {
-        UserAccountUpdate {
-            account_id,
-            params: UserAccountUpdateParams {
-                allow_tracking,
-                beta,
-                name,
-            },
-        }
-    }
-
-    pub fn create(account_id: String) -> UserAccountUpdate {
+impl<'a> UserAccountUpdate<'a> {
+    pub fn new(account_id: &'a str) -> UserAccountUpdate<'a> {
         UserAccountUpdate {
             account_id,
             params: UserAccountUpdateParams {
                 allow_tracking: None,
                 beta: None,
                 name: None,
+            },
+        }
+    }
+
+    pub fn allow_tracking(&mut self, allow_tracking: bool) -> &mut Self {
+        self.params.allow_tracking = Some(allow_tracking);
+        self
+    }
+
+    pub fn beta(&mut self, beta: bool) -> &mut Self {
+        self.params.beta = Some(beta);
+        self
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn build(&self) -> UserAccountUpdate<'a> {
+        UserAccountUpdate {
+            account_id: self.account_id,
+            params: UserAccountUpdateParams {
+                allow_tracking: self.params.allow_tracking,
+                beta: self.params.beta,
+                name: self.params.name,
             },
         }
     }
@@ -114,7 +136,7 @@ impl UserAccountUpdate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#account-update-by-user-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct UserAccountUpdateParams {
+pub struct UserAccountUpdateParams<'a> {
     /// whether to allow third party web activity tracking, by default: true
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_tracking: Option<bool>,
@@ -122,17 +144,17 @@ pub struct UserAccountUpdateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub beta: Option<bool>,
     /// full name of the account owner [Nullable]
-    pub name: Option<String>,
+    pub name: Option<&'a str>,
 }
 
-impl HerokuEndpoint<Account, (), UserAccountUpdateParams> for UserAccountUpdate {
+impl<'a> HerokuEndpoint<Account, (), UserAccountUpdateParams<'a>> for UserAccountUpdate<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("users/{}", self.account_id)
     }
-    fn body(&self) -> Option<UserAccountUpdateParams> {
+    fn body(&self) -> Option<UserAccountUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -142,15 +164,15 @@ impl HerokuEndpoint<Account, (), UserAccountUpdateParams> for UserAccountUpdate 
 /// Update an existing account feature.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#account-feature-update)
-pub struct AccountFeatureUpdate {
+pub struct AccountFeatureUpdate<'a> {
     /// feature_id can be the feature name or id.
-    pub feature_id: String,
+    pub feature_id: &'a str,
     /// The parameters to pass to the Heroku API
     pub params: AccountFeatureUpdateParams,
 }
 
-impl AccountFeatureUpdate {
-    pub fn new(feature_id: String, enabled: bool) -> AccountFeatureUpdate {
+impl<'a> AccountFeatureUpdate<'a> {
+    pub fn new(feature_id: &'a str, enabled: bool) -> AccountFeatureUpdate {
         AccountFeatureUpdate {
             feature_id,
             params: AccountFeatureUpdateParams { enabled },
@@ -168,7 +190,9 @@ pub struct AccountFeatureUpdateParams {
     pub enabled: bool,
 }
 
-impl HerokuEndpoint<AccountFeature, (), AccountFeatureUpdateParams> for AccountFeatureUpdate {
+impl<'a> HerokuEndpoint<AccountFeature, (), AccountFeatureUpdateParams>
+    for AccountFeatureUpdate<'a>
+{
     fn method(&self) -> Method {
         Method::Patch
     }
@@ -185,15 +209,15 @@ impl HerokuEndpoint<AccountFeature, (), AccountFeatureUpdateParams> for AccountF
 /// Update an existing app transfer.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-transfer-update)
-pub struct AppTransferUpdate {
+pub struct AppTransferUpdate<'a> {
     /// unique identifier or the transfer name
-    pub transfer_id: String,
+    pub transfer_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: AppTransferUpdateParams,
+    pub params: AppTransferUpdateParams<'a>,
 }
 
-impl AppTransferUpdate {
-    pub fn new(transfer_id: String, state: String) -> AppTransferUpdate {
+impl<'a> AppTransferUpdate<'a> {
+    pub fn new(transfer_id: &'a str, state: &'a str) -> AppTransferUpdate<'a> {
         AppTransferUpdate {
             transfer_id,
             params: AppTransferUpdateParams { state },
@@ -204,21 +228,20 @@ impl AppTransferUpdate {
 /// Update account app transfer with parameters.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-transfer-update-required-parameters)
-#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct AppTransferUpdateParams {
+pub struct AppTransferUpdateParams<'a> {
     /// the current state of an app transfer, one of:"pending" or "accepted" or "declined"
-    pub state: String,
+    pub state: &'a str,
 }
 
-impl HerokuEndpoint<AppTransfer, (), AppTransferUpdateParams> for AppTransferUpdate {
+impl <'a> HerokuEndpoint<AppTransfer, (), AppTransferUpdateParams<'a>> for AppTransferUpdate <'a>{
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("account/app-transfers/{}", self.transfer_id)
     }
-    fn body(&self) -> Option<AppTransferUpdateParams> {
+    fn body(&self) -> Option<AppTransferUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/account/post.rs
+++ b/src/endpoints/account/post.rs
@@ -8,28 +8,33 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Create a new app transfer.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-transfer-create)
-pub struct AppTransferCreate {
+pub struct AppTransferCreate<'a> {
     /// The parameters to pass to the Heroku API
-    pub params: AppTransferCreateParams,
+    pub params: AppTransferCreateParams<'a>,
 }
 
-impl AppTransferCreate {
-    pub fn new(app: String, recipient: String, silent: Option<bool>) -> AppTransferCreate {
-        AppTransferCreate {
-            params: AppTransferCreateParams {
-                app: app,
-                recipient: recipient,
-                silent: silent,
-            },
-        }
-    }
-
-    pub fn create(app: String, recipient: String) -> AppTransferCreate {
+impl<'a> AppTransferCreate<'a> {
+    pub fn new(app: &'a str, recipient: &'a str) -> AppTransferCreate<'a> {
         AppTransferCreate {
             params: AppTransferCreateParams {
                 app: app,
                 recipient: recipient,
                 silent: None,
+            },
+        }
+    }
+
+    pub fn silent(&mut self, silent: bool) -> &mut Self {
+        self.params.silent = Some(silent);
+        self
+    }
+
+    pub fn build(&self) -> AppTransferCreate<'a> {
+        AppTransferCreate {
+            params: AppTransferCreateParams {
+                app: self.params.app,
+                recipient: self.params.recipient,
+                silent: self.params.silent,
             },
         }
     }
@@ -40,23 +45,23 @@ impl AppTransferCreate {
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-transfer-create-required-parameters)
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct AppTransferCreateParams {
+pub struct AppTransferCreateParams<'a> {
     /// unique identifier or name of app
-    pub app: String,
+    pub app: &'a str,
     /// unique email address, identifier of an account or implicit reference to currently authorized user
-    pub recipient: String,
+    pub recipient: &'a str,
     /// whether to suppress email notification when transferring apps
     pub silent: Option<bool>,
 }
 
-impl HerokuEndpoint<AppTransfer, (), AppTransferCreateParams> for AppTransferCreate {
+impl<'a> HerokuEndpoint<AppTransfer, (), AppTransferCreateParams<'a>> for AppTransferCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("account/app-transfers")
     }
-    fn body(&self) -> Option<AppTransferCreateParams> {
+    fn body(&self) -> Option<AppTransferCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -66,15 +71,35 @@ impl HerokuEndpoint<AppTransfer, (), AppTransferCreateParams> for AppTransferCre
 /// Create a new credit.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#credit-create)
-pub struct AccountCreditCreate {
+pub struct AccountCreditCreate<'a> {
     /// The parameters to pass to the Heroku API
-    pub params: AccountCreditCreateParams,
+    pub params: AccountCreditCreateParams<'a>,
 }
 
-impl AccountCreditCreate {
-    pub fn new(code1: Option<String>, code2: Option<String>) -> AccountCreditCreate {
+impl<'a> AccountCreditCreate<'a> {
+    pub fn new() -> AccountCreditCreate<'a> {
         AccountCreditCreate {
-            params: AccountCreditCreateParams { code1, code2 },
+            params: AccountCreditCreateParams {
+                code1: None,
+                code2: None,
+            },
+        }
+    }
+    pub fn code_1(&mut self, code1: &'a str) -> &mut Self {
+        self.params.code1 = Some(code1);
+        self
+    }
+    pub fn code_2(&mut self, code2: &'a str) -> &mut Self {
+        self.params.code2 = Some(code2);
+        self
+    }
+
+    pub fn build(&self) -> AccountCreditCreate<'a> {
+        AccountCreditCreate {
+            params: AccountCreditCreateParams {
+                code1: self.params.code1,
+                code2: self.params.code2,
+            },
         }
     }
 }
@@ -84,21 +109,21 @@ impl AccountCreditCreate {
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#credit-create-optional-parameters)
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct AccountCreditCreateParams {
+pub struct AccountCreditCreateParams<'a> {
     /// first code from a discount card
-    pub code1: Option<String>,
+    pub code1: Option<&'a str>,
     /// second code from a discount card
-    pub code2: Option<String>,
+    pub code2: Option<&'a str>,
 }
 
-impl HerokuEndpoint<Credit, (), AccountCreditCreateParams> for AccountCreditCreate {
+impl<'a> HerokuEndpoint<Credit, (), AccountCreditCreateParams<'a>> for AccountCreditCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("account/credits")
     }
-    fn body(&self) -> Option<AccountCreditCreateParams> {
+    fn body(&self) -> Option<AccountCreditCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -108,13 +133,13 @@ impl HerokuEndpoint<Credit, (), AccountCreditCreateParams> for AccountCreditCrea
 /// Reset account’s password. This will send a reset password link to the user’s email address.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#passwordreset-reset-password)
-pub struct PasswordReset {
+pub struct PasswordReset<'a> {
     /// The parameters to pass to the Heroku API
-    pub params: PasswordResetParams,
+    pub params: PasswordResetParams<'a>,
 }
 
-impl PasswordReset {
-    pub fn new(email: String) -> PasswordReset {
+impl<'a> PasswordReset<'a> {
+    pub fn new(email: &'a str) -> PasswordReset {
         PasswordReset {
             params: PasswordResetParams { email },
         }
@@ -124,21 +149,20 @@ impl PasswordReset {
 /// Update account credits with parameters.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#passwordreset-reset-password-optional-parameters)
-#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct PasswordResetParams {
+pub struct PasswordResetParams<'a> {
     /// unique email address
-    pub email: String, // this isn't optional apparently...
+    pub email: &'a str, // this isn't optional(inacurate Heroku docs)
 }
 
-impl HerokuEndpoint<PasswordResetResponse, (), PasswordResetParams> for PasswordReset {
+impl<'a> HerokuEndpoint<PasswordResetResponse, (), PasswordResetParams<'a>> for PasswordReset<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("password-resets")
     }
-    fn body(&self) -> Option<PasswordResetParams> {
+    fn body(&self) -> Option<PasswordResetParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -148,24 +172,40 @@ impl HerokuEndpoint<PasswordResetResponse, (), PasswordResetParams> for Password
 /// Complete password reset.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#passwordreset-complete-reset-password)
-pub struct PasswordResetConfirm {
+pub struct PasswordResetConfirm<'a> {
     /// Password token
-    pub password_id: String,
+    pub password_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: PasswordResetConfirmParams,
+    pub params: PasswordResetConfirmParams<'a>,
 }
 
-impl PasswordResetConfirm {
-    pub fn new(
-        password_id: String,
-        password: String,
-        password_confirmation: String,
-    ) -> PasswordResetConfirm {
+impl<'a> PasswordResetConfirm<'a> {
+    pub fn new(password_id: &'a str) -> PasswordResetConfirm<'a> {
         PasswordResetConfirm {
             password_id,
             params: PasswordResetConfirmParams {
-                password,
-                password_confirmation,
+                password: None,
+                password_confirmation: None,
+            },
+        }
+    }
+
+    pub fn password(&mut self, password: &'a str) -> &mut Self {
+        self.params.password = Some(password);
+        self
+    }
+
+    pub fn password_confirmation(&mut self, password_confirmation: &'a str) -> &mut Self {
+        self.params.password_confirmation = Some(password_confirmation);
+        self
+    }
+
+    pub fn build(&self) -> PasswordResetConfirm<'a> {
+        PasswordResetConfirm {
+            password_id: self.password_id,
+            params: PasswordResetConfirmParams {
+                password: self.params.password,
+                password_confirmation: self.params.password_confirmation,
             },
         }
     }
@@ -173,18 +213,18 @@ impl PasswordResetConfirm {
 
 /// Update account credits with parameters.
 ///
-/// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#passwordreset-reset-password-optional-parameters)
+/// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#passwordreset-complete-reset-password-optional-parameters)
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct PasswordResetConfirmParams {
+pub struct PasswordResetConfirmParams<'a> {
     /// current password on the account
-    pub password: String,
+    pub password: Option<&'a str>,
     /// confirmation of the new password
-    pub password_confirmation: String,
+    pub password_confirmation: Option<&'a str>,
 }
 
-impl HerokuEndpoint<PasswordResetResponse, (), PasswordResetConfirmParams>
-    for PasswordResetConfirm
+impl<'a> HerokuEndpoint<PasswordResetResponse, (), PasswordResetConfirmParams<'a>>
+    for PasswordResetConfirm<'a>
 {
     fn method(&self) -> Method {
         Method::Post
@@ -192,7 +232,7 @@ impl HerokuEndpoint<PasswordResetResponse, (), PasswordResetConfirmParams>
     fn path(&self) -> String {
         format!("password-resets/{}/actions/finalize", self.password_id)
     }
-    fn body(&self) -> Option<PasswordResetConfirmParams> {
+    fn body(&self) -> Option<PasswordResetConfirmParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/account/put.rs
+++ b/src/endpoints/account/put.rs
@@ -13,26 +13,65 @@ pub struct InvoiceAddressUpdate<'a> {
 }
 
 impl<'a> InvoiceAddressUpdate<'a> {
-    pub fn new(
-        address_1: Option<&'a str>,
-        address_2: Option<&'a str>,
-        city: Option<&'a str>,
-        country: Option<&'a str>,
-        other: Option<&'a str>,
-        postal_code: Option<&'a str>,
-        state: Option<&'a str>,
-        use_invoice_address: bool,
-    ) -> InvoiceAddressUpdate<'a> {
+    pub fn new() -> InvoiceAddressUpdate<'a> {
         InvoiceAddressUpdate {
             params: InvoiceAddressUpdateParams {
-                address_1,
-                address_2,
-                city,
-                country,
-                other,
-                postal_code,
-                state,
-                use_invoice_address,
+                address_1: None,
+                address_2: None,
+                city: None,
+                country: None,
+                other: None,
+                postal_code: None,
+                state: None,
+                use_invoice_address: None,
+            },
+        }
+    }
+
+    pub fn address_1(&mut self, address_1: &'a str) -> &mut Self {
+        self.params.address_1 = Some(address_1);
+        self
+    }
+    pub fn address_2(&mut self, address_2: &'a str) -> &mut Self {
+        self.params.address_2 = Some(address_2);
+        self
+    }
+    pub fn city(&mut self, city: &'a str) -> &mut Self {
+        self.params.city = Some(city);
+        self
+    }
+    pub fn country(&mut self, country: &'a str) -> &mut Self {
+        self.params.country = Some(country);
+        self
+    }
+    pub fn other(&mut self, other: &'a str) -> &mut Self {
+        self.params.country = Some(other);
+        self
+    }
+    pub fn postal_code(&mut self, postal_code: &'a str) -> &mut Self {
+        self.params.postal_code = Some(postal_code);
+        self
+    }
+    pub fn state(&mut self, state: &'a str) -> &mut Self {
+        self.params.state = Some(state);
+        self
+    }
+    pub fn use_invoice_address(&mut self, use_invoice_address: bool) -> &mut Self {
+        self.params.use_invoice_address = Some(use_invoice_address);
+        self
+    }
+
+    pub fn build(&self) -> InvoiceAddressUpdate<'a> {
+        InvoiceAddressUpdate {
+            params: InvoiceAddressUpdateParams {
+                address_1: self.params.address_1,
+                address_2: self.params.address_2,
+                city: self.params.city,
+                country: self.params.country,
+                other: self.params.other,
+                postal_code: self.params.postal_code,
+                state: self.params.state,
+                use_invoice_address: self.params.use_invoice_address,
             },
         }
     }
@@ -41,6 +80,7 @@ impl<'a> InvoiceAddressUpdate<'a> {
 /// Update account invoice address with optional parameters.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#invoice-address-update-optional-parameters)
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
 pub struct InvoiceAddressUpdateParams<'a> {
     /// invoice street address line 1
@@ -58,7 +98,7 @@ pub struct InvoiceAddressUpdateParams<'a> {
     /// invoice state
     pub state: Option<&'a str>,
     /// flag to use the invoice address for an account or not
-    pub use_invoice_address: bool,
+    pub use_invoice_address: Option<bool>,
 }
 impl<'a> HerokuEndpoint<InvoiceAddress, (), InvoiceAddressUpdateParams<'a>>
     for InvoiceAddressUpdate<'a>

--- a/src/endpoints/addons/patch.rs
+++ b/src/endpoints/addons/patch.rs
@@ -18,26 +18,28 @@ pub struct AddonUpdate<'a> {
 }
 
 impl<'a> AddonUpdate<'a> {
-    pub fn new(
-        app_id: &'a str,
-        addon_id: &'a str,
-        plan: &'a str,
-        name: Option<&'a str>,
-    ) -> AddonUpdate<'a> {
-        AddonUpdate {
-            app_id,
-            addon_id,
-            params: AddonUpdateParams { plan, name },
-        }
-    }
-
-    pub fn create(app_id: &'a str, addon_id: &'a str, plan: &'a str) -> AddonUpdate<'a> {
+    pub fn new(app_id: &'a str, addon_id: &'a str, plan: &'a str) -> AddonUpdate<'a> {
         AddonUpdate {
             app_id,
             addon_id,
             params: AddonUpdateParams {
                 plan: plan,
                 name: None,
+            },
+        }
+    }
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn build(&self) -> AddonUpdate<'a> {
+        AddonUpdate {
+            app_id: self.app_id,
+            addon_id: self.addon_id,
+            params: AddonUpdateParams {
+                plan: self.params.plan,
+                name: self.params.name,
             },
         }
     }
@@ -81,11 +83,26 @@ pub struct AddonConfigUpdate<'a> {
 }
 
 impl<'a> AddonConfigUpdate<'a> {
-    pub fn new(addon_id: &'a str, config: Vec<AddonConfig>) -> AddonConfigUpdate<'a> {
+    pub fn new(addon_id: &'a str) -> AddonConfigUpdate<'a> {
         AddonConfigUpdate {
             addon_id,
+            params: AddonConfigUpdateParams { config: None },
+        }
+    }
+
+    pub fn config(&mut self, config_name: &'a str, config_value: &'a str) -> &mut Self {
+        self.params.config = Some(vec![AddonConfig {
+            name: config_name.to_owned(),
+            value: config_value.to_owned(),
+        }]);
+        self
+    }
+
+    pub fn build(&self) -> AddonConfigUpdate<'a> {
+        AddonConfigUpdate {
+            addon_id: self.addon_id,
             params: AddonConfigUpdateParams {
-                config: Some(config),
+                config: self.params.config.clone(),
             },
         }
     }
@@ -129,24 +146,52 @@ pub struct WebhookUpdate<'a> {
 
 impl<'a> WebhookUpdate<'a> {
     /// Update webhook with optional parameters
-    pub fn new(
-        addon_id: &'a str,
-        webhook_id: &'a str,
-        authorization: Option<&'a str>,
-        include: Option<Vec<&'a str>>,
-        level: Option<&'a str>,
-        secret: Option<&'a str>,
-        url: Option<&'a str>,
-    ) -> WebhookUpdate<'a> {
+    pub fn new(addon_id: &'a str, webhook_id: &'a str) -> WebhookUpdate<'a> {
         WebhookUpdate {
             addon_id,
             webhook_id,
             params: WebhookUpdateParams {
-                authorization,
-                include,
-                level,
-                secret,
-                url,
+                authorization: None,
+                include: None,
+                level: None,
+                secret: None,
+                url: None,
+            },
+        }
+    }
+
+    pub fn authorization(&mut self, authorization: &'a str) -> &mut Self {
+        self.params.authorization = Some(authorization);
+        self
+    }
+    pub fn include(&mut self, include: Vec<&'a str>) -> &mut Self {
+        self.params.include = Some(include);
+        self
+    }
+
+    pub fn level(&mut self, level: &'a str) -> &mut Self {
+        self.params.level = Some(level);
+        self
+    }
+    pub fn secret(&mut self, secret: &'a str) -> &mut Self {
+        self.params.secret = Some(secret);
+        self
+    }
+    pub fn url(&mut self, url: &'a str) -> &mut Self {
+        self.params.url = Some(url);
+        self
+    }
+
+    pub fn build(&self) -> WebhookUpdate<'a> {
+        WebhookUpdate {
+            addon_id: self.addon_id,
+            webhook_id: self.webhook_id,
+            params: WebhookUpdateParams {
+                authorization: self.params.authorization,
+                include: self.params.include.clone(),
+                level: self.params.level,
+                secret: self.params.secret,
+                url: self.params.url,
             },
         }
     }
@@ -154,7 +199,7 @@ impl<'a> WebhookUpdate<'a> {
 
 /// Update add-on webhooks with parameters.
 ///
-/// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#add-on-config-update-optional-parameters)
+/// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#add-on-webhook-update-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
 pub struct WebhookUpdateParams<'a> {
     /// a custom Authorization header that Heroku will include with all webhook notifications. [Nullable]

--- a/src/endpoints/addons/post.rs
+++ b/src/endpoints/addons/post.rs
@@ -14,31 +14,8 @@ pub struct AddonCreate<'a> {
 }
 
 impl<'a> AddonCreate<'a> {
-    /// Create a new addon with required and optional parameters
-    pub fn new(
-        app_id: &'a str,
-        plan: &'a str,
-        attachment_name: Option<&'a str>,
-        config: Option<HashMap<&'a str, &'a str>>,
-        confirm: Option<&'a str>,
-        name: Option<&'a str>,
-    ) -> AddonCreate<'a> {
-        AddonCreate {
-            app_id,
-            params: AddonCreateParams {
-                attachment: Some(Attachment {
-                    name: attachment_name,
-                }),
-                config: config,
-                plan: plan,
-                confirm: confirm,
-                name: name,
-            },
-        }
-    }
-
     /// Create a new addon without required parameters only
-    pub fn create(app_id: &'a str, plan: &'a str) -> AddonCreate<'a> {
+    pub fn new(app_id: &'a str, plan: &'a str) -> AddonCreate<'a> {
         AddonCreate {
             app_id,
             params: AddonCreateParams {
@@ -47,6 +24,40 @@ impl<'a> AddonCreate<'a> {
                 plan: plan,
                 confirm: None,
                 name: None,
+            },
+        }
+    }
+
+    pub fn attachment_name(&mut self, attachment_name: &'a str) -> &mut Self {
+        self.params.attachment = Some(Attachment {
+            name: Some(attachment_name),
+        });
+        self
+    }
+
+    pub fn config(&mut self, config: HashMap<&'a str, &'a str>) -> &mut Self {
+        self.params.config = Some(config);
+        self
+    }
+
+    pub fn confirm(&mut self, confirm: &'a str) -> &mut Self {
+        self.params.confirm = Some(confirm);
+        self
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+    pub fn build(&self) -> AddonCreate<'a> {
+        AddonCreate {
+            app_id: self.app_id,
+            params: AddonCreateParams {
+                attachment: self.params.attachment.clone(),
+                config: self.params.config.clone(),
+                plan: self.params.plan,
+                confirm: self.params.confirm,
+                name: self.params.name,
             },
         }
     }
@@ -100,28 +111,31 @@ pub struct AddonResolutionCreate<'a> {
 }
 
 impl<'a> AddonResolutionCreate<'a> {
-    /// Create a new addon with required and optional parameters
-    pub fn new(
-        addon: &'a str,
-        addon_service: Option<&'a str>,
-        app: Option<&'a str>,
-    ) -> AddonResolutionCreate<'a> {
-        AddonResolutionCreate {
-            params: AddonResolutionCreateParams {
-                addon,
-                addon_service,
-                app,
-            },
-        }
-    }
-
     /// Create a new addon resolution without optional parameters
-    pub fn create(addon: &'a str) -> AddonResolutionCreate<'a> {
+    pub fn new(addon: &'a str) -> AddonResolutionCreate<'a> {
         AddonResolutionCreate {
             params: AddonResolutionCreateParams {
                 addon: addon,
                 addon_service: None,
                 app: None,
+            },
+        }
+    }
+    pub fn addon_service(&mut self, addon_service: &'a str) -> &mut Self {
+        self.params.addon_service = Some(addon_service);
+        self
+    }
+    pub fn app(&mut self, app: &'a str) -> &mut Self {
+        self.params.app = Some(app);
+        self
+    }
+
+    pub fn build(&self) -> AddonResolutionCreate<'a> {
+        AddonResolutionCreate {
+            params: AddonResolutionCreateParams {
+                addon: self.params.addon,
+                addon_service: self.params.addon_service,
+                app: self.params.app,
             },
         }
     }
@@ -216,27 +230,8 @@ pub struct AttachmentCreate<'a> {
 }
 
 impl<'a> AttachmentCreate<'a> {
-    /// Create a new addon with required and optional parameters
-    pub fn new(
-        addon: &'a str,
-        app: &'a str,
-        confirm: Option<&'a str>,
-        name: Option<&'a str>,
-        namespace: Option<&'a str>,
-    ) -> AttachmentCreate<'a> {
-        AttachmentCreate {
-            params: AttachmentCreateParams {
-                addon,
-                app,
-                confirm,
-                name,
-                namespace,
-            },
-        }
-    }
-
     /// Create a new addon resolution without optional parameters
-    pub fn create(addon: &'a str, app: &'a str) -> AttachmentCreate<'a> {
+    pub fn new(addon: &'a str, app: &'a str) -> AttachmentCreate<'a> {
         AttachmentCreate {
             params: AttachmentCreateParams {
                 addon: addon,
@@ -244,6 +239,31 @@ impl<'a> AttachmentCreate<'a> {
                 confirm: None,
                 name: None,
                 namespace: None,
+            },
+        }
+    }
+
+    pub fn confirm(&mut self, confirm: &'a str) -> &mut Self {
+        self.params.confirm = Some(confirm);
+        self
+    }
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+    pub fn namespace(&mut self, namespace: &'a str) -> &mut Self {
+        self.params.namespace = Some(namespace);
+        self
+    }
+
+    pub fn build(&self) -> AttachmentCreate<'a> {
+        AttachmentCreate {
+            params: AttachmentCreateParams {
+                addon: self.params.addon,
+                app: self.params.app,
+                confirm: self.params.confirm,
+                name: self.params.name,
+                namespace: self.params.namespace,
             },
         }
     }
@@ -293,28 +313,32 @@ pub struct AttachmentResolutionCreate<'a> {
 }
 
 impl<'a> AttachmentResolutionCreate<'a> {
-    /// Create a new addon with required and optional parameters
-    pub fn new(
-        addon_attachment: &'a str,
-        addon_service: Option<&'a str>,
-        app: Option<&'a str>,
-    ) -> AttachmentResolutionCreate<'a> {
-        AttachmentResolutionCreate {
-            params: AttachmentResolutionCreateParams {
-                addon_attachment,
-                addon_service,
-                app,
-            },
-        }
-    }
-
     /// Create a new addon resolution without optional parameters
-    pub fn create(addon_attachment: &'a str) -> AttachmentResolutionCreate<'a> {
+    pub fn new(addon_attachment: &'a str) -> AttachmentResolutionCreate<'a> {
         AttachmentResolutionCreate {
             params: AttachmentResolutionCreateParams {
                 addon_attachment: addon_attachment,
                 addon_service: None,
                 app: None,
+            },
+        }
+    }
+    pub fn app(&mut self, app: &'a str) -> &mut Self {
+        self.params.app = Some(app);
+        self
+    }
+
+    pub fn addon_service(&mut self, addon_service: &'a str) -> &mut Self {
+        self.params.addon_service = Some(addon_service);
+        self
+    }
+
+    pub fn build(&self) -> AttachmentResolutionCreate<'a> {
+        AttachmentResolutionCreate {
+            params: AttachmentResolutionCreateParams {
+                addon_attachment: self.params.addon_attachment,
+                addon_service: self.params.addon_service,
+                app: self.params.app,
             },
         }
     }
@@ -362,29 +386,8 @@ pub struct WebhookCreate<'a> {
 }
 
 impl<'a> WebhookCreate<'a> {
-    /// Create a new addon webhook with required and optional parameters
-    pub fn new(
-        addon_id: &'a str,
-        authorization: Option<&'a str>,
-        include: Vec<&'a str>,
-        level: &'a str,
-        secret: Option<&'a str>,
-        url: &'a str,
-    ) -> WebhookCreate<'a> {
-        WebhookCreate {
-            addon_id,
-            params: WebhookCreateParams {
-                authorization,
-                include,
-                level,
-                secret,
-                url,
-            },
-        }
-    }
-
     /// Create a new addon webhook without optional parameters
-    pub fn create(
+    pub fn new(
         addon_id: &'a str,
         include: Vec<&'a str>,
         level: &'a str,
@@ -398,6 +401,29 @@ impl<'a> WebhookCreate<'a> {
                 level: level,
                 secret: None,
                 url: url,
+            },
+        }
+    }
+
+    pub fn authorization(&mut self, authorization: &'a str) -> &mut Self {
+        self.params.authorization = Some(authorization);
+        self
+    }
+
+    pub fn secret(&mut self, secret: &'a str) -> &mut Self {
+        self.params.secret = Some(secret);
+        self
+    }
+
+    pub fn build(&self) -> WebhookCreate<'a> {
+        WebhookCreate {
+            addon_id: self.addon_id,
+            params: WebhookCreateParams {
+                authorization: None,
+                include: self.params.include.clone(),
+                level: self.params.level,
+                secret: self.params.secret,
+                url: self.params.url,
             },
         }
     }

--- a/src/endpoints/apps/delete.rs
+++ b/src/endpoints/apps/delete.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Delete an existing app.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-delete)
-pub struct AppDelete {
+pub struct AppDelete<'a> {
     /// app_id can be the app id or app name.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppDelete {
-    pub fn new(app_id: String) -> AppDelete {
+impl<'a> AppDelete<'a> {
+    pub fn new(app_id: &'a str) -> AppDelete {
         AppDelete { app_id }
     }
 }
 
-impl HerokuEndpoint<App> for AppDelete {
+impl<'a> HerokuEndpoint<App> for AppDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }
@@ -33,18 +33,18 @@ impl HerokuEndpoint<App> for AppDelete {
 /// Disable ACM flag for an app
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-disable-acm)
-pub struct AppDisableAcm {
+pub struct AppDisableAcm<'a> {
     /// app_id can be the app id or name.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppDisableAcm {
-    pub fn new(app_id: String) -> AppDisableAcm {
+impl<'a> AppDisableAcm<'a> {
+    pub fn new(app_id: &'a str) -> AppDisableAcm {
         AppDisableAcm { app_id }
     }
 }
 
-impl HerokuEndpoint<App> for AppDisableAcm {
+impl<'a> HerokuEndpoint<App> for AppDisableAcm<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }
@@ -58,20 +58,19 @@ impl HerokuEndpoint<App> for AppDisableAcm {
 /// Removes an app webhook subscription.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-delete)
-pub struct AppWebhookDelete {
+pub struct AppWebhookDelete<'a> {
     /// app_id can be the app id or app name.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// webhook_id is the webhook id.
-    pub webhook_id: String,
+    pub webhook_id: &'a str,
 }
-
-impl AppWebhookDelete {
-    pub fn new(app_id: String, webhook_id: String) -> AppWebhookDelete {
+impl<'a> AppWebhookDelete<'a> {
+    pub fn new(app_id: &'a str, webhook_id: &'a str) -> AppWebhookDelete<'a> {
         AppWebhookDelete { app_id, webhook_id }
     }
 }
 
-impl HerokuEndpoint<AppWebhook> for AppWebhookDelete {
+impl<'a> HerokuEndpoint<AppWebhook> for AppWebhookDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/apps/get.rs
+++ b/src/endpoints/apps/get.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Get info for existing app.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-info)
-pub struct AppDetails {
+pub struct AppDetails<'a> {
     /// app_id can be the app id or app name.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppDetails {
-    pub fn new(app_id: String) -> AppDetails {
+impl<'a> AppDetails<'a> {
+    pub fn new(app_id: &'a str) -> AppDetails {
         AppDetails { app_id }
     }
 }
 
-impl HerokuEndpoint<App> for AppDetails {
+impl<'a> HerokuEndpoint<App> for AppDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -55,18 +55,18 @@ impl HerokuEndpoint<Vec<App>> for AppList {
 /// List owned and collaborated apps (excludes team apps).
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-list-owned-and-collaborated)
-pub struct AccountAppList {
+pub struct AccountAppList<'a> {
     /// account_id can be the account email, id or self.
-    pub account_id: String,
+    pub account_id: &'a str,
 }
 
-impl AccountAppList {
-    pub fn new(account_id: String) -> AccountAppList {
+impl<'a> AccountAppList<'a> {
+    pub fn new(account_id: &'a str) -> AccountAppList<'a> {
         AccountAppList { account_id }
     }
 }
 
-impl HerokuEndpoint<Vec<App>> for AccountAppList {
+impl<'a> HerokuEndpoint<Vec<App>> for AccountAppList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -80,20 +80,20 @@ impl HerokuEndpoint<Vec<App>> for AccountAppList {
 /// Info for an existing app feature.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-feature-info)
-pub struct AppFeatureDetails {
+pub struct AppFeatureDetails<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// feature_id can be the feature name or id.
-    pub feature_id: String,
+    pub feature_id: &'a str,
 }
 
-impl AppFeatureDetails {
-    pub fn new(app_id: String, feature_id: String) -> AppFeatureDetails {
+impl<'a> AppFeatureDetails<'a> {
+    pub fn new(app_id: &'a str, feature_id: &'a str) -> AppFeatureDetails<'a> {
         AppFeatureDetails { app_id, feature_id }
     }
 }
 
-impl HerokuEndpoint<AppFeature> for AppFeatureDetails {
+impl<'a> HerokuEndpoint<AppFeature> for AppFeatureDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -107,18 +107,18 @@ impl HerokuEndpoint<AppFeature> for AppFeatureDetails {
 /// List existing app features.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-feature-list)
-pub struct AppFeatureList {
+pub struct AppFeatureList<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppFeatureList {
-    pub fn new(app_id: String) -> AppFeatureList {
+impl<'a> AppFeatureList<'a> {
+    pub fn new(app_id: &'a str) -> AppFeatureList {
         AppFeatureList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<AppFeature>> for AppFeatureList {
+impl<'a> HerokuEndpoint<Vec<AppFeature>> for AppFeatureList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -132,18 +132,18 @@ impl HerokuEndpoint<Vec<AppFeature>> for AppFeatureList {
 /// List all webhook subscriptions for a particular app.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-list)
-pub struct AppWebhookList {
+pub struct AppWebhookList<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppWebhookList {
-    pub fn new(app_id: String) -> AppWebhookList {
+impl<'a> AppWebhookList<'a> {
+    pub fn new(app_id: &'a str) -> AppWebhookList<'a> {
         AppWebhookList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<AppWebhook>> for AppWebhookList {
+impl<'a> HerokuEndpoint<Vec<AppWebhook>> for AppWebhookList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -157,20 +157,20 @@ impl HerokuEndpoint<Vec<AppWebhook>> for AppWebhookList {
 /// Returns the info for an app webhook subscription.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-info)
-pub struct AppWebhookDetails {
+pub struct AppWebhookDetails<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// webhook_id is the webhook id.
-    pub webhook_id: String,
+    pub webhook_id: &'a str,
 }
 
-impl AppWebhookDetails {
-    pub fn new(app_id: String, webhook_id: String) -> AppWebhookDetails {
+impl<'a> AppWebhookDetails<'a> {
+    pub fn new(app_id: &'a str, webhook_id: &'a str) -> AppWebhookDetails<'a> {
         AppWebhookDetails { app_id, webhook_id }
     }
 }
 
-impl HerokuEndpoint<AppWebhook> for AppWebhookDetails {
+impl<'a> HerokuEndpoint<AppWebhook> for AppWebhookDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -184,15 +184,15 @@ impl HerokuEndpoint<AppWebhook> for AppWebhookDetails {
 /// Returns the info for an existing delivery.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-delivery-info)
-pub struct AppWebhookDeliveryDetails {
+pub struct AppWebhookDeliveryDetails<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// webhook_delivery_id is the webhook delivery id.
-    pub webhook_delivery_id: String,
+    pub webhook_delivery_id: &'a str,
 }
 
-impl AppWebhookDeliveryDetails {
-    pub fn new(app_id: String, webhook_delivery_id: String) -> AppWebhookDeliveryDetails {
+impl<'a> AppWebhookDeliveryDetails<'a> {
+    pub fn new(app_id: &'a str, webhook_delivery_id: &'a str) -> AppWebhookDeliveryDetails<'a> {
         AppWebhookDeliveryDetails {
             app_id,
             webhook_delivery_id,
@@ -200,7 +200,7 @@ impl AppWebhookDeliveryDetails {
     }
 }
 
-impl HerokuEndpoint<AppWebhookDelivery> for AppWebhookDeliveryDetails {
+impl<'a> HerokuEndpoint<AppWebhookDelivery> for AppWebhookDeliveryDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -217,18 +217,18 @@ impl HerokuEndpoint<AppWebhookDelivery> for AppWebhookDeliveryDetails {
 /// Lists existing deliveries for an app.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-delivery-list)
-pub struct AppWebhookDeliveryList {
+pub struct AppWebhookDeliveryList<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppWebhookDeliveryList {
-    pub fn new(app_id: String) -> AppWebhookDeliveryList {
+impl<'a> AppWebhookDeliveryList<'a> {
+    pub fn new(app_id: &'a str) -> AppWebhookDeliveryList {
         AppWebhookDeliveryList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<AppWebhookDelivery>> for AppWebhookDeliveryList {
+impl<'a> HerokuEndpoint<Vec<AppWebhookDelivery>> for AppWebhookDeliveryList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -242,18 +242,18 @@ impl HerokuEndpoint<Vec<AppWebhookDelivery>> for AppWebhookDeliveryList {
 /// Get the status of an app setup.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-setup-info)
-pub struct AppSetupDetails {
+pub struct AppSetupDetails<'a> {
     /// setup_id is the unique setup identifier.
-    pub setup_id: String,
+    pub setup_id: &'a str,
 }
 
-impl AppSetupDetails {
-    pub fn new(setup_id: String) -> AppSetupDetails {
+impl <'a>AppSetupDetails <'a>{
+    pub fn new(setup_id: &'a str) -> AppSetupDetails<'a> {
         AppSetupDetails { setup_id }
     }
 }
 
-impl HerokuEndpoint<AppSetup> for AppSetupDetails {
+impl <'a>HerokuEndpoint<AppSetup> for AppSetupDetails <'a>{
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/apps/patch.rs
+++ b/src/endpoints/apps/patch.rs
@@ -8,39 +8,47 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Update an existing app.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-update)
-pub struct AppUpdate {
+pub struct AppUpdate<'a> {
     /// app_id can be either app id or app name.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// params are the parameters sent to the API to patch the App.
-    pub params: AppUpdateParams,
+    pub params: AppUpdateParams<'a>,
 }
 
-impl AppUpdate {
-    /// Update a Heroku app with optional parameters
-    pub fn new(
-        app_id: String,
-        build_stack: Option<String>,
-        maintenance: Option<bool>,
-        name: Option<String>,
-    ) -> AppUpdate {
-        AppUpdate {
-            app_id,
-            params: AppUpdateParams {
-                build_stack,
-                maintenance,
-                name,
-            },
-        }
-    }
-
+impl<'a> AppUpdate<'a> {
     /// Update a Heroku app without optional parameters
-    pub fn create(app_id: String) -> AppUpdate {
+    pub fn new(app_id: &'a str) -> AppUpdate {
         AppUpdate {
             app_id: app_id,
             params: AppUpdateParams {
                 build_stack: None,
                 maintenance: None,
                 name: None,
+            },
+        }
+    }
+    pub fn build_stack(&mut self, build_stack: &'a str) -> &mut Self {
+        self.params.build_stack = Some(build_stack);
+        self
+    }
+
+    pub fn maintenance(&mut self, maintenance: bool) -> &mut Self {
+        self.params.maintenance = Some(maintenance);
+        self
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn build(&self) -> AppUpdate<'a> {
+        AppUpdate {
+            app_id: self.app_id,
+            params: AppUpdateParams {
+                build_stack: self.params.build_stack,
+                maintenance: self.params.maintenance,
+                name: self.params.name,
             },
         }
     }
@@ -51,23 +59,23 @@ impl AppUpdate {
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-update-optional-parameters)
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct AppUpdateParams {
+pub struct AppUpdateParams<'a> {
     /// unique name or identifier of stack
-    pub build_stack: Option<String>,
+    pub build_stack: Option<&'a str>,
     /// maintenance status of app
     pub maintenance: Option<bool>,
     /// name of app. pattern: ^[a-z][a-z0-9-]{1,28}[a-z0-9]$
-    pub name: Option<String>,
+    pub name: Option<&'a str>,
 }
 
-impl HerokuEndpoint<App, (), AppUpdateParams> for AppUpdate {
+impl<'a> HerokuEndpoint<App, (), AppUpdateParams<'a>> for AppUpdate<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("apps/{}", self.app_id)
     }
-    fn body(&self) -> Option<AppUpdateParams> {
+    fn body(&self) -> Option<AppUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -77,18 +85,18 @@ impl HerokuEndpoint<App, (), AppUpdateParams> for AppUpdate {
 /// Refresh ACM for an app
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-refresh-acm)
-pub struct AppRefreshAcm {
+pub struct AppRefreshAcm<'a> {
     /// app_id can be either app id or app name.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppRefreshAcm {
-    pub fn new(app_id: String) -> AppRefreshAcm {
+impl<'a> AppRefreshAcm<'a> {
+    pub fn new(app_id: &'a str) -> AppRefreshAcm<'a> {
         AppRefreshAcm { app_id }
     }
 }
 
-impl HerokuEndpoint<App> for AppRefreshAcm {
+impl<'a> HerokuEndpoint<App> for AppRefreshAcm<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
@@ -102,17 +110,17 @@ impl HerokuEndpoint<App> for AppRefreshAcm {
 /// Update an existing app feature.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-feature-update)
-pub struct AppFeatureUpdate {
+pub struct AppFeatureUpdate<'a> {
     /// app_id can be either app id or app name.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// feature_id can be either feature id or feature name.
-    pub feature_id: String,
+    pub feature_id: &'a str,
     /// params are the parameters sent to the API to patch the feature.
     pub params: AppFeatureUpdateParams,
 }
 
-impl AppFeatureUpdate {
-    pub fn new(app_id: String, feature_id: String, enabled: bool) -> AppFeatureUpdate {
+impl<'a> AppFeatureUpdate<'a> {
+    pub fn new(app_id: &'a str, feature_id: &'a str, enabled: bool) -> AppFeatureUpdate<'a> {
         AppFeatureUpdate {
             app_id,
             feature_id,
@@ -131,7 +139,7 @@ pub struct AppFeatureUpdateParams {
     pub enabled: bool,
 }
 
-impl HerokuEndpoint<AppFeature, (), AppFeatureUpdateParams> for AppFeatureUpdate {
+impl<'a> HerokuEndpoint<AppFeature, (), AppFeatureUpdateParams> for AppFeatureUpdate<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
@@ -148,34 +156,65 @@ impl HerokuEndpoint<AppFeature, (), AppFeatureUpdateParams> for AppFeatureUpdate
 /// Updates the details of an app webhook subscription.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-update)
-pub struct AppWebhookUpdate {
+pub struct AppWebhookUpdate<'a> {
     /// app_id can be the app id or app name.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// webhook_id is the webhook id.
-    pub webhook_id: String,
+    pub webhook_id: &'a str,
     /// params are the parameters sent to the API to patch the webhook.
-    pub params: AppWebhookUpdateParams,
+    pub params: AppWebhookUpdateParams<'a>,
 }
 
-impl AppWebhookUpdate {
-    pub fn new(
-        app_id: String,
-        webhook_id: String,
-        authorization: Option<String>,
-        include: Option<Vec<String>>,
-        level: Option<String>,
-        secret: Option<String>,
-        url: Option<String>,
-    ) -> AppWebhookUpdate {
+impl<'a> AppWebhookUpdate<'a> {
+    pub fn new(app_id: &'a str, webhook_id: &'a str) -> AppWebhookUpdate<'a> {
         AppWebhookUpdate {
             app_id,
             webhook_id,
             params: AppWebhookUpdateParams {
-                authorization,
-                include,
-                level,
-                secret,
-                url,
+                authorization: None,
+                include: None,
+                level: None,
+                secret: None,
+                url: None,
+            },
+        }
+    }
+
+    pub fn authorization(&mut self, authorization: &'a str) -> &mut Self {
+        self.params.authorization = Some(authorization);
+        self
+    }
+
+    pub fn include(&mut self, include: Vec<&'a str>) -> &mut Self {
+        self.params.include = Some(include);
+        self
+    }
+
+    pub fn level(&mut self, level: &'a str) -> &mut Self {
+        self.params.level = Some(level);
+        self
+    }
+
+    pub fn secret(&mut self, secret: &'a str) -> &mut Self {
+        self.params.secret = Some(secret);
+        self
+    }
+
+    pub fn url(&mut self, url: &'a str) -> &mut Self {
+        self.params.url = Some(url);
+        self
+    }
+
+    pub fn build(&self) -> AppWebhookUpdate<'a> {
+        AppWebhookUpdate {
+            app_id: self.app_id,
+            webhook_id: self.webhook_id,
+            params: AppWebhookUpdateParams {
+                authorization: self.params.authorization,
+                include: self.params.include.clone(),
+                level: self.params.level,
+                secret: self.params.secret,
+                url: self.params.url,
             },
         }
     }
@@ -187,31 +226,31 @@ impl AppWebhookUpdate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-update-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct AppWebhookUpdateParams {
+pub struct AppWebhookUpdateParams<'a> {
     /// A custom Authorization header that Heroku will include with all webhook notifications [Nullable]
-    pub authorization: Option<String>,
+    pub authorization: Option<&'a str>,
     /// The entities that the subscription provides notifications for
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub include: Option<Vec<String>>,
+    pub include: Option<Vec<&'a str>>,
     /// One of: "notify" or "sync"
     /// If notify, Heroku makes a single, fire-and-forget delivery attempt. If sync, Heroku attempts multiple deliveries until the request is successful or a limit is reached
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub level: Option<String>,
+    pub level: Option<&'a str>,
     /// A value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s Heroku-Webhook-Hmac-SHA256 header) [Nullable]
-    pub secret: Option<String>,
+    pub secret: Option<&'a str>,
     /// The URL where the webhook’s notification requests are sent
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: Option<&'a str>,
 }
 
-impl HerokuEndpoint<AppWebhook, (), AppWebhookUpdateParams> for AppWebhookUpdate {
+impl<'a> HerokuEndpoint<AppWebhook, (), AppWebhookUpdateParams<'a>> for AppWebhookUpdate<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("apps/{}/webhooks/{}", self.app_id, self.webhook_id)
     }
-    fn body(&self) -> Option<AppWebhookUpdateParams> {
+    fn body(&self) -> Option<AppWebhookUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -288,20 +327,40 @@ pub struct SSLUpdate<'a> {
 
 impl<'a> SSLUpdate<'a> {
     /// Update Heroku app SSL with parameters
-    pub fn new(
-        app_id: &'a str,
-        ssl_id: &'a str,
-        certificate_chain: Option<&'a str>,
-        private_key: Option<&'a str>,
-        preprocess: Option<bool>,
-    ) -> SSLUpdate<'a> {
+    pub fn new(app_id: &'a str, ssl_id: &'a str) -> SSLUpdate<'a> {
         SSLUpdate {
             app_id,
             ssl_id,
             params: SSLUpdateParams {
-                certificate_chain,
-                private_key,
-                preprocess,
+                certificate_chain: None,
+                private_key: None,
+                preprocess: None,
+            },
+        }
+    }
+
+    pub fn certificate_chain(&mut self, certificate_chain: &'a str) -> &mut Self {
+        self.params.certificate_chain = Some(certificate_chain);
+        self
+    }
+
+    pub fn private_key(&mut self, private_key: &'a str) -> &mut Self {
+        self.params.private_key = Some(private_key);
+        self
+    }
+
+    pub fn preprocess(&mut self, preprocess: bool) -> &mut Self {
+        self.params.preprocess = Some(preprocess);
+        self
+    }
+    pub fn build(&self) -> SSLUpdate<'a> {
+        SSLUpdate {
+            app_id: self.app_id,
+            ssl_id: self.ssl_id,
+            params: SSLUpdateParams {
+                certificate_chain: self.params.certificate_chain,
+                private_key: self.params.private_key,
+                preprocess: self.params.preprocess,
             },
         }
     }

--- a/src/endpoints/apps/post.rs
+++ b/src/endpoints/apps/post.rs
@@ -9,30 +9,44 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Create a new app.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-create)
-pub struct AppCreate {
+pub struct AppCreate<'a> {
     /// The parameters to pass to the Heroku API
-    pub params: AppCreateParams,
+    pub params: AppCreateParams<'a>,
 }
 
-impl AppCreate {
-    /// Create a new Heroku app with parameters
-    pub fn new(name: Option<String>, region: Option<String>, stack: Option<String>) -> AppCreate {
-        AppCreate {
-            params: AppCreateParams {
-                name,
-                region,
-                stack,
-            },
-        }
-    }
-
+impl<'a> AppCreate<'a> {
     /// Create a new Heroku app without parameters
-    pub fn create() -> AppCreate {
+    pub fn new() -> AppCreate<'a> {
         AppCreate {
             params: AppCreateParams {
                 name: None,
                 region: None,
                 stack: None,
+            },
+        }
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn region(&mut self, region: &'a str) -> &mut Self {
+        self.params.region = Some(region);
+        self
+    }
+
+    pub fn stack(&mut self, stack: &'a str) -> &mut Self {
+        self.params.stack = Some(stack);
+        self
+    }
+
+    pub fn build(&self) -> AppCreate<'a> {
+        AppCreate {
+            params: AppCreateParams {
+                name: self.params.name,
+                region: self.params.region,
+                stack: self.params.stack,
             },
         }
     }
@@ -45,23 +59,23 @@ impl AppCreate {
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-create-optional-parameters)
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct AppCreateParams {
+pub struct AppCreateParams<'a> {
     /// name of app. pattern: ^[a-z][a-z0-9-]{1,28}[a-z0-9]$
-    pub name: Option<String>,
+    pub name: Option<&'a str>,
     /// unique identifier or name of region
-    pub region: Option<String>,
+    pub region: Option<&'a str>,
     /// unique name or identifier of stack
-    pub stack: Option<String>,
+    pub stack: Option<&'a str>,
 }
 
-impl HerokuEndpoint<App, (), AppCreateParams> for AppCreate {
+impl<'a> HerokuEndpoint<App, (), AppCreateParams<'a>> for AppCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps")
     }
-    fn body(&self) -> Option<AppCreateParams> {
+    fn body(&self) -> Option<AppCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -71,18 +85,18 @@ impl HerokuEndpoint<App, (), AppCreateParams> for AppCreate {
 /// Enable ACM flag for an app
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-enable-acm)
-pub struct AppEnableAcm {
+pub struct AppEnableAcm<'a> {
     /// app_id can be the app id or name.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl AppEnableAcm {
-    pub fn new(app_id: String) -> AppEnableAcm {
+impl<'a> AppEnableAcm<'a> {
+    pub fn new(app_id: &'a str) -> AppEnableAcm<'a> {
         AppEnableAcm { app_id }
     }
 }
 
-impl HerokuEndpoint<App> for AppEnableAcm {
+impl<'a> HerokuEndpoint<App> for AppEnableAcm<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
@@ -96,41 +110,21 @@ impl HerokuEndpoint<App> for AppEnableAcm {
 /// Create an app webhook subscription.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-create)
-pub struct AppWebhookCreate {
+pub struct AppWebhookCreate<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: AppWebhookCreateParams,
+    pub params: AppWebhookCreateParams<'a>,
 }
 
-impl AppWebhookCreate {
-    /// Create a new webhook with optional parameters
-    pub fn new(
-        app_id: String,
-        authorization: Option<String>,
-        include: Vec<String>,
-        level: String,
-        secret: Option<String>,
-        url: String,
-    ) -> AppWebhookCreate {
-        AppWebhookCreate {
-            app_id,
-            params: AppWebhookCreateParams {
-                authorization,
-                include,
-                level,
-                secret,
-                url,
-            },
-        }
-    }
+impl<'a> AppWebhookCreate<'a> {
     /// Create a new webhook without optional parameters
-    pub fn create(
-        app_id: String,
-        include: Vec<String>,
-        level: String,
-        url: String,
-    ) -> AppWebhookCreate {
+    pub fn new(
+        app_id: &'a str,
+        include: Vec<&'a str>,
+        level: &'a str,
+        url: &'a str,
+    ) -> AppWebhookCreate<'a> {
         AppWebhookCreate {
             app_id: app_id,
             params: AppWebhookCreateParams {
@@ -142,34 +136,57 @@ impl AppWebhookCreate {
             },
         }
     }
+
+    pub fn authorization(&mut self, authorization: &'a str) -> &mut Self {
+        self.params.authorization = Some(authorization);
+        self
+    }
+
+    pub fn secret(&mut self, secret: &'a str) -> &mut Self {
+        self.params.secret = Some(secret);
+        self
+    }
+
+    pub fn build(&self) -> AppWebhookCreate<'a> {
+        AppWebhookCreate {
+            app_id: self.app_id,
+            params: AppWebhookCreateParams {
+                authorization: self.params.authorization,
+                include: self.params.include.clone(),
+                level: self.params.level,
+                secret: self.params.secret,
+                url: self.params.url,
+            },
+        }
+    }
 }
 
 /// Create a new app webhook with parameters.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-webhook-create-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct AppWebhookCreateParams {
+pub struct AppWebhookCreateParams<'a> {
     /// A custom Authorization header that Heroku will include with all webhook notifications
-    pub authorization: Option<String>,
+    pub authorization: Option<&'a str>,
     /// The entities that the subscription provides notifications for
-    pub include: Vec<String>,
+    pub include: Vec<&'a str>,
     /// One of: "notify" or "sync"
     /// If notify, Heroku makes a single, fire-and-forget delivery attempt. If sync, Heroku attempts multiple deliveries until the request is successful or a limit is reached
-    pub level: String,
+    pub level: &'a str,
     /// A value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s Heroku-Webhook-Hmac-SHA256 header)
-    pub secret: Option<String>,
+    pub secret: Option<&'a str>,
     /// The URL where the webhook’s notification requests are sent
-    pub url: String,
+    pub url: &'a str,
 }
 
-impl HerokuEndpoint<AppWebhook, (), AppWebhookCreateParams> for AppWebhookCreate {
+impl<'a> HerokuEndpoint<AppWebhook, (), AppWebhookCreateParams<'a>> for AppWebhookCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps/{}/webhooks", self.app_id)
     }
-    fn body(&self) -> Option<AppWebhookCreateParams> {
+    fn body(&self) -> Option<AppWebhookCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -185,68 +202,89 @@ pub struct AppSetupCreate<'a> {
 }
 
 impl<'a> AppSetupCreate<'a> {
-    /// Create a new Heroku app with required  and optional parameters
-    // :| needs a better solution. Builder pattern?
-    pub fn new(
-        locked: Option<bool>,
-        name: Option<&'a str>,
-        organization: Option<&'a str>,
-        personal: Option<bool>,
-        region: Option<&'a str>,
-        space: Option<&'a str>,
-        stack: Option<&'a str>,
-        checksum: Option<&'a str>,
-        url: &'a str,
-        version: Option<&'a str>,
-        buildpacks_list: Option<Vec<&'a str>>,
-        env: Option<HashMap<&'a str, &'a str>>,
-    ) -> AppSetupCreate<'a> {
-        let buildpacks: Option<Vec<Buildpack>> = match buildpacks_list {
-            Some(buidpacks) => {
-                let mut buildpacks: Vec<Buildpack> = Vec::new();
-                for var in buidpacks {
-                    buildpacks.push(Buildpack { url: var });
-                }
-                Some(buildpacks)
-            }
-            None => None,
-        };
+    /// Create a new setup app with required parameters only
+    pub fn new(url: &'a str) -> AppSetupCreate<'a> {
         AppSetupCreate {
             params: AppSetupCreateParams {
-                app: Some(SetupApp {
-                    locked,
-                    name,
-                    organization,
-                    personal,
-                    region,
-                    space,
-                    stack,
-                }),
-                source_blob: SourceBlob {
-                    checksum,
-                    url,
-                    version,
+                app: SetupApp {
+                    locked: None,
+                    name: None,
+                    organization: None,
+                    personal: None,
+                    region: None,
+                    space: None,
+                    stack: None,
                 },
-                overrides: Some(Overrides { buildpacks, env }),
+                source_blob: SourceBlob {
+                    checksum: None,
+                    url: url,
+                    version: None,
+                },
+                overrides: Overrides {
+                    buildpacks: None,
+                    env: None,
+                },
             },
         }
     }
 
-    /// Create a new setup app with required parameters only
-    pub fn create(
-        checksum: Option<&'a str>,
-        url: &'a str,
-        version: Option<&'a str>,
-    ) -> AppSetupCreate<'a> {
+    pub fn version(&mut self, version: &'a str) -> &mut Self {
+        self.params.source_blob.version = Some(version);
+        self
+    }
+    pub fn checksum(&mut self, checksum: &'a str) -> &mut Self {
+        self.params.source_blob.checksum = Some(checksum);
+        self
+    }
+
+    pub fn locked(&mut self, locked: bool) -> &mut Self {
+        self.params.app.locked = Some(locked);
+        self
+    }
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.app.name = Some(name);
+        self
+    }
+    pub fn organization(&mut self, organization: &'a str) -> &mut Self {
+        self.params.app.organization = Some(organization);
+        self
+    }
+    pub fn personal(&mut self, personal: bool) -> &mut Self {
+        self.params.app.personal = Some(personal);
+        self
+    }
+    pub fn region(&mut self, region: &'a str) -> &mut Self {
+        self.params.app.region = Some(region);
+        self
+    }
+    pub fn space(&mut self, space: &'a str) -> &mut Self {
+        self.params.app.space = Some(space);
+        self
+    }
+    pub fn stack(&mut self, stack: &'a str) -> &mut Self {
+        self.params.app.stack = Some(stack);
+        self
+    }
+
+    pub fn buildpacks(&mut self, buildpacks_list: Vec<&'a str>) -> &mut Self {
+        let mut buildpacks: Vec<Buildpack> = Vec::new();
+        for var in buildpacks_list {
+            buildpacks.push(Buildpack { url: var });
+        }
+        self.params.overrides.buildpacks = Some(buildpacks);
+        self
+    }
+    pub fn env(&mut self, env: HashMap<&'a str, &'a str>) -> &mut Self {
+        self.params.overrides.env = Some(env);
+        self
+    }
+    /// Create a new Heroku app with required  and optional parameters
+    pub fn build(&self) -> AppSetupCreate<'a> {
         AppSetupCreate {
             params: AppSetupCreateParams {
-                app: None,
-                source_blob: SourceBlob {
-                    checksum,
-                    url,
-                    version,
-                },
-                overrides: None,
+                app: self.params.app.clone(),
+                source_blob: self.params.source_blob.clone(),
+                overrides: self.params.overrides.clone(),
             },
         }
     }
@@ -260,9 +298,9 @@ impl<'a> AppSetupCreate<'a> {
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
 pub struct AppSetupCreateParams<'a> {
-    pub app: Option<SetupApp<'a>>,
+    pub app: SetupApp<'a>,
     pub source_blob: SourceBlob<'a>,
-    pub overrides: Option<Overrides<'a>>,
+    pub overrides: Overrides<'a>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -389,22 +427,6 @@ impl<'a> SSLCreate<'a> {
         app_id: &'a str,
         certificate_chain: &'a str,
         private_key: &'a str,
-        preprocess: Option<bool>,
-    ) -> SSLCreate<'a> {
-        SSLCreate {
-            app_id,
-            params: SSLCreateParams {
-                certificate_chain,
-                private_key,
-                preprocess,
-            },
-        }
-    }
-    /// Create a new Heroku app SSL with required parameters only
-    pub fn create(
-        app_id: &'a str,
-        certificate_chain: &'a str,
-        private_key: &'a str,
     ) -> SSLCreate<'a> {
         SSLCreate {
             app_id,
@@ -412,6 +434,21 @@ impl<'a> SSLCreate<'a> {
                 certificate_chain: certificate_chain,
                 private_key: private_key,
                 preprocess: None,
+            },
+        }
+    }
+
+    pub fn preprocess(&mut self, preprocess: bool) -> &mut Self {
+        self.params.preprocess = Some(preprocess);
+        self
+    }
+    pub fn build(&self) -> SSLCreate<'a> {
+        SSLCreate {
+            app_id: self.app_id,
+            params: SSLCreateParams {
+                certificate_chain: self.params.certificate_chain,
+                private_key: self.params.private_key,
+                preprocess: self.params.preprocess,
             },
         }
     }

--- a/src/endpoints/builds/delete.rs
+++ b/src/endpoints/builds/delete.rs
@@ -6,18 +6,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Destroy a build cache.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#build-delete-cache)
-pub struct BuildDelete {
+pub struct BuildDelete<'a> {
     /// app_id can be the app id or name.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl BuildDelete {
-    pub fn new(app_id: String) -> BuildDelete {
+impl <'a>BuildDelete <'a>{
+    pub fn new(app_id: &'a str) -> BuildDelete<'a> {
         BuildDelete { app_id }
     }
 }
 
-impl HerokuEndpoint for BuildDelete {
+impl<'a> HerokuEndpoint for BuildDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/builds/get.rs
+++ b/src/endpoints/builds/get.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// List existing builds.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#build-list)
-pub struct BuildList {
+pub struct BuildList<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl BuildList {
-    pub fn new(app_id: String) -> BuildList {
+impl<'a> BuildList<'a> {
+    pub fn new(app_id: &'a str) -> BuildList<'a> {
         BuildList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<Build>> for BuildList {
+impl<'a> HerokuEndpoint<Vec<Build>> for BuildList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -33,20 +33,20 @@ impl HerokuEndpoint<Vec<Build>> for BuildList {
 /// Info for existing build.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#build-info)
-pub struct BuildDetails {
+pub struct BuildDetails <'a>{
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// build_id is the build identifier which you want to get
-    pub build_id: String,
+    pub build_id: &'a str,
 }
 
-impl BuildDetails {
-    pub fn new(app_id: String, build_id: String) -> BuildDetails {
+impl<'a> BuildDetails<'a> {
+    pub fn new(app_id: &'a str, build_id: &'a str) -> BuildDetails<'a> {
         BuildDetails { app_id, build_id }
     }
 }
 
-impl HerokuEndpoint<Build> for BuildDetails {
+impl<'a> HerokuEndpoint<Build> for BuildDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -60,18 +60,18 @@ impl HerokuEndpoint<Build> for BuildDetails {
 /// List an app’s existing buildpack installations.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#buildpack-installations-list)
-pub struct BuildPackInstallationList {
+pub struct BuildPackInstallationList<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl BuildPackInstallationList {
-    pub fn new(app_id: String) -> BuildPackInstallationList {
+impl<'a> BuildPackInstallationList<'a> {
+    pub fn new(app_id: &'a str) -> BuildPackInstallationList<'a> {
         BuildPackInstallationList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<BuildpackInstallation>> for BuildPackInstallationList {
+impl<'a> HerokuEndpoint<Vec<BuildpackInstallation>> for BuildPackInstallationList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/builds/put.rs
+++ b/src/endpoints/builds/put.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Update an app’s buildpack installations.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#buildpack-installations-update)
-pub struct BuildpackInstallationUpdate {
+pub struct BuildpackInstallationUpdate<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
     pub params: BuildpackInstallationUpdateParams,
 }
 
-impl BuildpackInstallationUpdate {
-    pub fn new(app_id: String, buildpacks: Vec<String>) -> BuildpackInstallationUpdate {
+impl<'a> BuildpackInstallationUpdate<'a> {
+    pub fn new(app_id: &'a str, buildpacks: Vec<&'a str>) -> BuildpackInstallationUpdate<'a> {
         let mut updates = Vec::new();
         for var in buildpacks {
-            updates.push(Update { buildpack: var });
+            updates.push(Update { buildpack: var.to_owned() });
         }
 
         BuildpackInstallationUpdate {
@@ -33,13 +33,13 @@ impl BuildpackInstallationUpdate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#buildpack-installations-update-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct BuildpackInstallationUpdateParams {
+pub struct BuildpackInstallationUpdateParams{
     /// The buildpack attribute can accept a name, a url, or a urn.
     pub updates: Vec<Update>,
 }
 
-impl HerokuEndpoint<Vec<BuildpackInstallation>, (), BuildpackInstallationUpdateParams>
-    for BuildpackInstallationUpdate
+impl<'a> HerokuEndpoint<Vec<BuildpackInstallation>, (), BuildpackInstallationUpdateParams>
+    for BuildpackInstallationUpdate<'a>
 {
     fn method(&self) -> Method {
         Method::Put

--- a/src/endpoints/collaborators/delete.rs
+++ b/src/endpoints/collaborators/delete.rs
@@ -8,15 +8,15 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Delete an existing collaborator.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#collaborator-delete)
-pub struct CollaboratorDelete {
+pub struct CollaboratorDelete<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// collaborator_id can be the collaborator email or id.
-    pub collaborator_id: String,
+    pub collaborator_id: &'a str,
 }
 
-impl CollaboratorDelete {
-    pub fn new(app_id: String, collaborator_id: String) -> CollaboratorDelete {
+impl<'a> CollaboratorDelete<'a> {
+    pub fn new(app_id: &'a str, collaborator_id: &'a str) -> CollaboratorDelete<'a> {
         CollaboratorDelete {
             app_id,
             collaborator_id,
@@ -24,7 +24,7 @@ impl CollaboratorDelete {
     }
 }
 
-impl HerokuEndpoint<Collaborator> for CollaboratorDelete {
+impl<'a> HerokuEndpoint<Collaborator> for CollaboratorDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/collaborators/get.rs
+++ b/src/endpoints/collaborators/get.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// List existing collaborators.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#collaborator-list)
-pub struct CollaboratorList {
+pub struct CollaboratorList<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl CollaboratorList {
-    pub fn new(app_id: String) -> CollaboratorList {
+impl<'a> CollaboratorList<'a> {
+    pub fn new(app_id: &'a str) -> CollaboratorList {
         CollaboratorList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<Collaborator>> for CollaboratorList {
+impl<'a> HerokuEndpoint<Vec<Collaborator>> for CollaboratorList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -34,15 +34,15 @@ impl HerokuEndpoint<Vec<Collaborator>> for CollaboratorList {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#collaborator-info)
 ///
-pub struct CollaboratorDetails {
+pub struct CollaboratorDetails<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// collaborator_id can be the collaborator email or id.
-    pub collaborator_id: String,
+    pub collaborator_id: &'a str,
 }
 
-impl CollaboratorDetails {
-    pub fn new(app_id: String, collaborator_id: String) -> CollaboratorDetails {
+impl<'a> CollaboratorDetails<'a> {
+    pub fn new(app_id: &'a str, collaborator_id: &'a str) -> CollaboratorDetails<'a> {
         CollaboratorDetails {
             app_id,
             collaborator_id,
@@ -50,7 +50,7 @@ impl CollaboratorDetails {
     }
 }
 
-impl HerokuEndpoint<Collaborator> for CollaboratorDetails {
+impl<'a> HerokuEndpoint<Collaborator> for CollaboratorDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/collaborators/post.rs
+++ b/src/endpoints/collaborators/post.rs
@@ -8,27 +8,32 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Create a new collaborator.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#collaborator-create)
-pub struct CollaboratorCreate {
+pub struct CollaboratorCreate<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: CollaboratorCreateParams,
+    pub params: CollaboratorCreateParams<'a>,
 }
 
-impl CollaboratorCreate {
-    pub fn new(app_id: String, user: String, silent: Option<bool>) -> CollaboratorCreate {
+impl<'a> CollaboratorCreate<'a> {
+    pub fn new(app_id: &'a str, user: &'a str) -> CollaboratorCreate<'a> {
         CollaboratorCreate {
             app_id,
-            params: CollaboratorCreateParams { user, silent },
+            params: CollaboratorCreateParams { user, silent: None },
         }
     }
 
-    pub fn create(app_id: String, user: String) -> CollaboratorCreate {
+    pub fn silent(&mut self, silent: bool) -> &mut Self {
+        self.params.silent = Some(silent);
+        self
+    }
+
+    pub fn build(&self) -> CollaboratorCreate<'a> {
         CollaboratorCreate {
-            app_id,
+            app_id: self.app_id,
             params: CollaboratorCreateParams {
-                user: user,
-                silent: None,
+                user: self.params.user,
+                silent: self.params.silent,
             },
         }
     }
@@ -38,22 +43,22 @@ impl CollaboratorCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#collaborator-create-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct CollaboratorCreateParams {
+pub struct CollaboratorCreateParams<'a> {
     /// unique email address, identifier of an account or Implicit reference to currently authorized user
-    pub user: String,
+    pub user: &'a str,
     /// whether to suppress email invitation when creating collaborator
     #[serde(skip_serializing_if = "Option::is_none")]
     pub silent: Option<bool>,
 }
 
-impl HerokuEndpoint<Collaborator, (), CollaboratorCreateParams> for CollaboratorCreate {
+impl<'a> HerokuEndpoint<Collaborator, (), CollaboratorCreateParams<'a>> for CollaboratorCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps/{}/collaborators", self.app_id)
     }
-    fn body(&self) -> Option<CollaboratorCreateParams> {
+    fn body(&self) -> Option<CollaboratorCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -71,29 +76,34 @@ pub struct TeamCollaboratorCreate<'a> {
 }
 
 impl<'a> TeamCollaboratorCreate<'a> {
-    pub fn new(
-        app_id: &'a str,
-        user: &'a str,
-        silent: Option<bool>,
-        permissions: Option<Vec<&'a str>>,
-    ) -> TeamCollaboratorCreate<'a> {
-        TeamCollaboratorCreate {
-            app_id,
-            params: TeamCollaboratorCreateParams {
-                user,
-                silent,
-                permissions,
-            },
-        }
-    }
-
-    pub fn create(app_id: &'a str, user: &'a str) -> TeamCollaboratorCreate<'a> {
+    pub fn new(app_id: &'a str, user: &'a str) -> TeamCollaboratorCreate<'a> {
         TeamCollaboratorCreate {
             app_id,
             params: TeamCollaboratorCreateParams {
                 user: user,
                 silent: None,
                 permissions: None,
+            },
+        }
+    }
+
+    pub fn silent(&mut self, silent: bool) -> &mut Self {
+        self.params.silent = Some(silent);
+        self
+    }
+
+    pub fn permissions(&mut self, permissions: Vec<&'a str>) -> &mut Self {
+        self.params.permissions = Some(permissions);
+        self
+    }
+
+    pub fn build(&self) -> TeamCollaboratorCreate<'a> {
+        TeamCollaboratorCreate {
+            app_id: self.app_id,
+            params: TeamCollaboratorCreateParams {
+                user: self.params.user,
+                silent: self.params.silent,
+                permissions: self.params.permissions.clone(),
             },
         }
     }

--- a/src/endpoints/domains/delete.rs
+++ b/src/endpoints/domains/delete.rs
@@ -8,20 +8,20 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Delete an existing domain
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#domain-delete)
-pub struct DomainDelete {
+pub struct DomainDelete<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// domain_id can be the domain hostname or id.
-    pub domain_id: String,
+    pub domain_id: &'a str,
 }
 
-impl DomainDelete {
-    pub fn new(app_id: String, domain_id: String) -> DomainDelete {
+impl<'a> DomainDelete<'a> {
+    pub fn new(app_id: &'a str, domain_id: &'a str) -> DomainDelete<'a> {
         DomainDelete { app_id, domain_id }
     }
 }
 
-impl HerokuEndpoint<Domain> for DomainDelete {
+impl<'a> HerokuEndpoint<Domain> for DomainDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/domains/get.rs
+++ b/src/endpoints/domains/get.rs
@@ -8,20 +8,20 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Info for existing domain.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#domain-info)
-pub struct DomainDetails {
+pub struct DomainDetails<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// domain_id can be the domain hostname or id.
-    pub domain_id: String,
+    pub domain_id: &'a str,
 }
 
-impl DomainDetails {
-    pub fn new(app_id: String, domain_id: String) -> DomainDetails {
+impl <'a>DomainDetails <'a>{
+    pub fn new(app_id: &'a str, domain_id: &'a str) -> DomainDetails<'a> {
         DomainDetails { app_id, domain_id }
     }
 }
 
-impl HerokuEndpoint<Domain> for DomainDetails {
+impl <'a>HerokuEndpoint<Domain> for DomainDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -35,18 +35,18 @@ impl HerokuEndpoint<Domain> for DomainDetails {
 /// List existing domains.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#domain-list)
-pub struct DomainList {
+pub struct DomainList<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl DomainList {
-    pub fn new(app_id: String) -> DomainList {
+impl<'a> DomainList<'a> {
+    pub fn new(app_id: &'a str) -> DomainList<'a> {
         DomainList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<Domain>> for DomainList {
+impl<'a> HerokuEndpoint<Vec<Domain>> for DomainList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/domains/post.rs
+++ b/src/endpoints/domains/post.rs
@@ -8,15 +8,15 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Create a new domain.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#domain-create)
-pub struct DomainCreate {
+pub struct DomainCreate<'a> {
     /// app_id can be the app name or id.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: DomainCreateParams,
+    pub params: DomainCreateParams<'a>,
 }
 
-impl DomainCreate {
-    pub fn new(app_id: String, hostname: String) -> DomainCreate {
+impl<'a> DomainCreate<'a> {
+    pub fn new(app_id: &'a str, hostname: &'a str) -> DomainCreate<'a> {
         DomainCreate {
             app_id,
             params: DomainCreateParams { hostname },
@@ -28,19 +28,19 @@ impl DomainCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#domain-create-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct DomainCreateParams {
+pub struct DomainCreateParams<'a> {
     /// full hostname
-    pub hostname: String,
+    pub hostname: &'a str,
 }
 
-impl HerokuEndpoint<Domain, (), DomainCreateParams> for DomainCreate {
+impl<'a> HerokuEndpoint<Domain, (), DomainCreateParams<'a>> for DomainCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps/{}/domains", self.app_id)
     }
-    fn body(&self) -> Option<DomainCreateParams> {
+    fn body(&self) -> Option<DomainCreateParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/dynos/delete.rs
+++ b/src/endpoints/dynos/delete.rs
@@ -7,20 +7,20 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Restart dyno.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#dyno-restart)
-pub struct DynoRestart {
+pub struct DynoRestart<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// dyno_id can be the dyno name or the dyno id
-    pub dyno_id: String,
+    pub dyno_id: &'a str,
 }
 
-impl DynoRestart {
-    pub fn new(app_id: String, dyno_id: String) -> DynoRestart {
+impl<'a> DynoRestart<'a> {
+    pub fn new(app_id: &'a str, dyno_id: &'a str) -> DynoRestart<'a> {
         DynoRestart { app_id, dyno_id }
     }
 }
 
-impl HerokuEndpoint for DynoRestart {
+impl<'a> HerokuEndpoint for DynoRestart<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }
@@ -34,18 +34,18 @@ impl HerokuEndpoint for DynoRestart {
 /// Restart all dynos.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#dyno-restart-all)
-pub struct DynoAllRestart {
+pub struct DynoAllRestart<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl DynoAllRestart {
-    pub fn new(app_id: String) -> DynoAllRestart {
+impl<'a> DynoAllRestart<'a> {
+    pub fn new(app_id: &'a str) -> DynoAllRestart<'a> {
         DynoAllRestart { app_id }
     }
 }
 
-impl HerokuEndpoint for DynoAllRestart {
+impl<'a> HerokuEndpoint for DynoAllRestart<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/dynos/get.rs
+++ b/src/endpoints/dynos/get.rs
@@ -9,20 +9,20 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Get info for existing dyno.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#dyno-info)
-pub struct DynoDetails {
+pub struct DynoDetails<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// dyno_id can be the dyno name or the dyno id
-    pub dyno_id: String,
+    pub dyno_id: &'a str,
 }
 
-impl DynoDetails {
-    pub fn new(app_id: String, dyno_id: String) -> DynoDetails {
+impl<'a> DynoDetails<'a> {
+    pub fn new(app_id: &'a str, dyno_id: &'a str) -> DynoDetails<'a> {
         DynoDetails { app_id, dyno_id }
     }
 }
 
-impl HerokuEndpoint<Dyno> for DynoDetails {
+impl<'a> HerokuEndpoint<Dyno> for DynoDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -36,18 +36,18 @@ impl HerokuEndpoint<Dyno> for DynoDetails {
 /// List existing dynos.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#dyno-list)
-pub struct DynoList {
+pub struct DynoList<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl DynoList {
-    pub fn new(app_id: String) -> DynoList {
+impl<'a> DynoList<'a> {
+    pub fn new(app_id: &'a str) -> DynoList<'a> {
         DynoList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<Dyno>> for DynoList {
+impl<'a> HerokuEndpoint<Vec<Dyno>> for DynoList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/dynos/post.rs
+++ b/src/endpoints/dynos/post.rs
@@ -10,20 +10,20 @@ use std::collections::HashMap;
 /// Stop dyno.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference##dyno-stop)
-pub struct DynoActionStop {
+pub struct DynoActionStop<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// dyno_id can be the dyno name or the dyno id
-    pub dyno_id: String,
+    pub dyno_id: &'a str,
 }
 
-impl DynoActionStop {
-    pub fn new(app_id: String, dyno_id: String) -> DynoActionStop {
+impl<'a> DynoActionStop<'a> {
+    pub fn new(app_id: &'a str, dyno_id: &'a str) -> DynoActionStop<'a> {
         DynoActionStop { app_id, dyno_id }
     }
 }
 
-impl HerokuEndpoint<Dyno> for DynoActionStop {
+impl<'a> HerokuEndpoint<Dyno> for DynoActionStop<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
@@ -37,38 +37,15 @@ impl HerokuEndpoint<Dyno> for DynoActionStop {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#dyno-create)
 #[derive(Serialize)]
-pub struct DynoCreate {
+pub struct DynoCreate<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: DynoCreateParams,
+    pub params: DynoCreateParams<'a>,
 }
 
-impl DynoCreate {
-    pub fn new(
-        app_id: String,
-        command: String,
-        attach: Option<bool>,
-        env: Option<HashMap<String, String>>,
-        force_no_tty: Option<bool>,
-        size: Option<String>,
-        time_to_live: Option<i32>,
-        process_type: Option<String>,
-    ) -> DynoCreate {
-        DynoCreate {
-            app_id,
-            params: DynoCreateParams {
-                command: command,
-                attach: attach,
-                env: env,
-                force_no_tty: force_no_tty,
-                size: size,
-                time_to_live: time_to_live,
-                r#type: process_type,
-            },
-        }
-    }
-    pub fn create(app_id: String, command: String) -> DynoCreate {
+impl<'a> DynoCreate<'a> {
+    pub fn new(app_id: &'a str, command: &'a str) -> DynoCreate<'a> {
         DynoCreate {
             app_id,
             params: DynoCreateParams {
@@ -79,6 +56,51 @@ impl DynoCreate {
                 size: None,
                 time_to_live: None,
                 r#type: None,
+            },
+        }
+    }
+
+    pub fn attach(&mut self, attach: bool) -> &mut Self {
+        self.params.attach = Some(attach);
+        self
+    }
+
+    pub fn env(&mut self, env: HashMap<&'a str, &'a str>) -> &mut Self {
+        self.params.env = Some(env);
+        self
+    }
+
+    pub fn force_no_tty(&mut self, force_no_tty: bool) -> &mut Self {
+        self.params.force_no_tty = Some(force_no_tty);
+        self
+    }
+
+    pub fn size(&mut self, size: &'a str) -> &mut Self {
+        self.params.size = Some(size);
+        self
+    }
+
+    pub fn time_to_live(&mut self, time_to_live: i32) -> &mut Self {
+        self.params.time_to_live = Some(time_to_live);
+        self
+    }
+
+    pub fn dyno_type(&mut self, dyno_type: &'a str) -> &mut Self {
+        self.params.r#type = Some(dyno_type);
+        self
+    }
+
+    pub fn build(&self) -> DynoCreate<'a> {
+        DynoCreate {
+            app_id: self.app_id,
+            params: DynoCreateParams {
+                command: self.params.command,
+                attach: self.params.attach,
+                env: self.params.env.clone(),
+                force_no_tty: self.params.force_no_tty,
+                size: self.params.size,
+                time_to_live: self.params.time_to_live,
+                r#type: self.params.r#type,
             },
         }
     }
@@ -94,36 +116,36 @@ impl DynoCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#app-create-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct DynoCreateParams {
+pub struct DynoCreateParams<'a> {
     /// command used to start process
-    pub command: String,
+    pub command: &'a str,
     /// whether to stream output or not
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attach: Option<bool>,
     /// custom environment to add to the dyno config vars
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub env: Option<HashMap<String, String>>,
+    pub env: Option<HashMap<&'a str, &'a str>>,
     /// force an attached on-off dyno to not run in a tty [Nullable]
     pub force_no_tty: Option<bool>,
     /// dyno size
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub size: Option<String>,
+    pub size: Option<&'a str>,
     /// seconds until dyno expires
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_to_live: Option<i32>,
     /// type of process
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub r#type: Option<String>,
+    pub r#type: Option<&'a str>,
 }
 
-impl HerokuEndpoint<Dyno, (), DynoCreateParams> for DynoCreate {
+impl<'a> HerokuEndpoint<Dyno, (), DynoCreateParams<'a>> for DynoCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps/{}/dynos", self.app_id)
     }
-    fn body(&self) -> Option<DynoCreateParams> {
+    fn body(&self) -> Option<DynoCreateParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/formations/get.rs
+++ b/src/endpoints/formations/get.rs
@@ -9,15 +9,15 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Get info for a process type
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#dyno-info)
-pub struct FormationDetails {
+pub struct FormationDetails<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
-    /// formation_id can be the formation id or type
-    pub formation_id: String,
+    pub app_id: &'a str,
+    /// formation_id can &'a str the formation id or type
+    pub formation_id: &'a str,
 }
 
-impl FormationDetails {
-    pub fn new(app_id: String, formation_id: String) -> FormationDetails {
+impl<'a> FormationDetails <'a>{
+    pub fn new(app_id: &'a str, formation_id: &'a str) -> FormationDetails <'a>{
         FormationDetails {
             app_id,
             formation_id,
@@ -25,7 +25,7 @@ impl FormationDetails {
     }
 }
 
-impl HerokuEndpoint<Formation> for FormationDetails {
+impl <'a>HerokuEndpoint<Formation> for FormationDetails <'a>{
     fn method(&self) -> Method {
         Method::Get
     }
@@ -38,18 +38,18 @@ impl HerokuEndpoint<Formation> for FormationDetails {
 ///
 /// List process type formation
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#formation-list)
-pub struct FormationList {
+pub struct FormationList <'a>{
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl FormationList {
-    pub fn new(app_id: String) -> FormationList {
+impl<'a> FormationList <'a>{
+    pub fn new(app_id: &'a str) -> FormationList<'a> {
         FormationList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<Formation>> for FormationList {
+impl<'a> HerokuEndpoint<Vec<Formation>> for FormationList <'a>{
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/logs/post.rs
+++ b/src/endpoints/logs/post.rs
@@ -54,34 +54,49 @@ pub struct LogSessionCreate<'a> {
     /// unique app identifier, either app name, or app id
     pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: Option<LogSessionCreateParams<'a>>,
+    pub params: LogSessionCreateParams<'a>,
 }
 
 impl<'a> LogSessionCreate<'a> {
     /// Create a new log session with required parameters
-    pub fn new(
-        app_id: &'a str,
-        dyno: Option<&'a str>,
-        lines: Option<i64>,
-        source: Option<&'a str>,
-        tail: Option<bool>,
-    ) -> LogSessionCreate<'a> {
+    pub fn new(app_id: &'a str) -> LogSessionCreate<'a> {
         LogSessionCreate {
             app_id,
-            params: Some(LogSessionCreateParams {
-                dyno: dyno,
-                lines: lines,
-                source: source,
-                tail: tail,
-            }),
+            params: LogSessionCreateParams {
+                dyno: None,
+                lines: None,
+                source: None,
+                tail: None,
+            },
         }
     }
 
-    /// Create a new log session without parameters
-    pub fn create(app_id: &'a str) -> LogSessionCreate<'a> {
+    pub fn dyno(&mut self, dyno: &'a str) -> &mut Self {
+        self.params.dyno = Some(dyno);
+        self
+    }
+    pub fn lines(&mut self, lines: i64) -> &mut Self {
+        self.params.lines = Some(lines);
+        self
+    }
+    pub fn source(&mut self, source: &'a str) -> &mut Self {
+        self.params.source = Some(source);
+        self
+    }
+    pub fn tail(&mut self, tail: bool) -> &mut Self {
+        self.params.tail = Some(tail);
+        self
+    }
+
+    pub fn build(&self) -> LogSessionCreate<'a> {
         LogSessionCreate {
-            app_id,
-            params: None,
+            app_id: self.app_id,
+            params: LogSessionCreateParams {
+                dyno: self.params.dyno,
+                lines: self.params.lines,
+                source: self.params.source,
+                tail: self.params.tail,
+            },
         }
     }
 }
@@ -109,6 +124,6 @@ impl<'a> HerokuEndpoint<LogSession, (), LogSessionCreateParams<'a>> for LogSessi
         format!("apps/{}/log-sessions", self.app_id)
     }
     fn body(&self) -> Option<LogSessionCreateParams<'a>> {
-        self.params.clone()
+        Some(self.params.clone())
     }
 }

--- a/src/endpoints/misc/get.rs
+++ b/src/endpoints/misc/get.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Info for existing region.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#region-info)
-pub struct RegionDetails {
+pub struct RegionDetails<'a> {
     /// region_id can be the region name or region id
-    pub region_id: String,
+    pub region_id: &'a str,
 }
 
-impl RegionDetails {
-    pub fn new(region_id: String) -> RegionDetails {
+impl<'a> RegionDetails<'a> {
+    pub fn new(region_id: &'a str) -> RegionDetails<'a> {
         RegionDetails { region_id }
     }
 }
 
-impl HerokuEndpoint<Region> for RegionDetails {
+impl<'a> HerokuEndpoint<Region> for RegionDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -99,18 +99,18 @@ impl HerokuEndpoint<Vec<Stack>> for StackList {
 /// Info about a specific stack.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#stack-info)
-pub struct StackDetails {
+pub struct StackDetails<'a> {
     /// stack_id can be the stack name or stack id
-    pub stack_id: String,
+    pub stack_id: &'a str,
 }
 
-impl StackDetails {
-    pub fn new(stack_id: String) -> StackDetails {
+impl<'a> StackDetails<'a> {
+    pub fn new(stack_id: &'a str) -> StackDetails<'a> {
         StackDetails { stack_id }
     }
 }
 
-impl HerokuEndpoint<Stack> for StackDetails {
+impl<'a> HerokuEndpoint<Stack> for StackDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -10,7 +10,7 @@ pub mod apps;
 pub mod builds;
 /// collaborators endpoints
 pub mod collaborators;
-/// config vars
+/// config vars endpoints
 // app config vars, pipeline config vars, release config vars
 pub mod config_vars;
 /// custom endpoints
@@ -21,21 +21,21 @@ pub mod domains;
 pub mod dynos;
 /// formations endpoints
 pub mod formations;
-/// heroku logs
+/// heroku logs endpoints
 pub mod logs;
 /// mixed endpoints
 pub mod misc; // used for those one off endpoints e.g. ratelimiting, region, stacks etc.
-/// OAuth Authorization
+/// oauth endpoints
 pub mod oauth;
-/// pipelines
+/// pipeline endpoints
 pub mod pipelines;
-/// releases
+/// release endpoints
 pub mod releases;
-/// app review
+/// app review endpoints
 pub mod review;
 /// slug endpoints
 pub mod slugs;
-/// teams
+/// teams endpoints
 pub mod teams;
-/// spaces
+/// spaces endpoints
 pub mod space;

--- a/src/endpoints/oauth/delete.rs
+++ b/src/endpoints/oauth/delete.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Delete OAuth authorization.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#oauth-authorization-delete)
-pub struct OAuthDelete {
+pub struct OAuthDelete<'a> {
     /// unique identifier of OAuth authorization
-    pub oauth_id: String,
+    pub oauth_id: &'a str,
 }
 
-impl OAuthDelete {
-    pub fn new(oauth_id: String) -> OAuthDelete {
+impl<'a> OAuthDelete<'a> {
+    pub fn new(oauth_id: &'a str) -> OAuthDelete<'a> {
         OAuthDelete { oauth_id }
     }
 }
 
-impl HerokuEndpoint<OAuth, (), ()> for OAuthDelete {
+impl<'a> HerokuEndpoint<OAuth> for OAuthDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }
@@ -33,18 +33,18 @@ impl HerokuEndpoint<OAuth, (), ()> for OAuthDelete {
 /// Delete OAuth client.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#oauth-client-delete)
-pub struct OAuthClientDelete {
+pub struct OAuthClientDelete<'a> {
     /// unique identifier of OAuth Client authorization
-    pub client_id: String,
+    pub client_id: &'a str,
 }
 
-impl OAuthClientDelete {
-    pub fn new(client_id: String) -> OAuthClientDelete {
+impl<'a> OAuthClientDelete<'a> {
+    pub fn new(client_id: &'a str) -> OAuthClientDelete<'a> {
         OAuthClientDelete { client_id }
     }
 }
 
-impl HerokuEndpoint<OAuthClient, (), ()> for OAuthClientDelete {
+impl<'a> HerokuEndpoint<OAuthClient, (), ()> for OAuthClientDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }
@@ -58,18 +58,18 @@ impl HerokuEndpoint<OAuthClient, (), ()> for OAuthClientDelete {
 /// Revoke OAuth access token.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#oauth-token-delete)
-pub struct OAuthTokenDelete {
+pub struct OAuthTokenDelete<'a> {
     /// unique identifier of token
-    pub token_id: String,
+    pub token_id: &'a str,
 }
 
-impl OAuthTokenDelete {
-    pub fn new(token_id: String) -> OAuthTokenDelete {
+impl<'a> OAuthTokenDelete<'a> {
+    pub fn new(token_id: &'a str) -> OAuthTokenDelete<'a> {
         OAuthTokenDelete { token_id }
     }
 }
 
-impl HerokuEndpoint<OAuthToken, (), ()> for OAuthTokenDelete {
+impl<'a> HerokuEndpoint<OAuthToken, (), ()> for OAuthTokenDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/oauth/get.rs
+++ b/src/endpoints/oauth/get.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Info for an OAuth authorization.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#oauth-authorization-info)
-pub struct OAuthDetails {
+pub struct OAuthDetails<'a> {
     /// oauth_id is the unique identifier.
-    pub oauth_id: String,
+    pub oauth_id: &'a str,
 }
 
-impl OAuthDetails {
-    pub fn new(oauth_id: String) -> OAuthDetails {
+impl<'a> OAuthDetails<'a> {
+    pub fn new(oauth_id: &'a str) -> OAuthDetails<'a> {
         OAuthDetails { oauth_id }
     }
 }
 
-impl HerokuEndpoint<OAuth> for OAuthDetails {
+impl<'a> HerokuEndpoint<OAuth> for OAuthDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -55,18 +55,18 @@ impl HerokuEndpoint<Vec<OAuth>> for OAuthList {
 /// Info for an OAuth client
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#oauth-client-info)
-pub struct OAuthClientDetails {
+pub struct OAuthClientDetails<'a> {
     /// unique identifier of OAuth Client authorization
-    pub client_id: String,
+    pub client_id: &'a str,
 }
 
-impl OAuthClientDetails {
-    pub fn new(client_id: String) -> OAuthClientDetails {
+impl<'a> OAuthClientDetails<'a> {
+    pub fn new(client_id: &'a str) -> OAuthClientDetails<'a> {
         OAuthClientDetails { client_id }
     }
 }
 
-impl HerokuEndpoint<OAuthClient> for OAuthClientDetails {
+impl<'a> HerokuEndpoint<OAuthClient> for OAuthClientDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/oauth/patch.rs
+++ b/src/endpoints/oauth/patch.rs
@@ -8,18 +8,41 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Update OAuth client
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#oauth-client-update)
-pub struct OAuthClientUpdate {
+pub struct OAuthClientUpdate<'a> {
     /// unique identifier of OAuth Client authorization
-    pub client_id: String,
+    pub client_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: OAuthClientUpdateParams,
+    pub params: OAuthClientUpdateParams<'a>,
 }
 
-impl OAuthClientUpdate {
-    pub fn new(client_id: String, name: String, redirect_uri: String) -> OAuthClientUpdate {
+impl<'a> OAuthClientUpdate<'a> {
+    pub fn new(client_id: &'a str) -> OAuthClientUpdate<'a> {
         OAuthClientUpdate {
             client_id,
-            params: OAuthClientUpdateParams { name, redirect_uri },
+            params: OAuthClientUpdateParams {
+                name: None,
+                redirect_uri: None,
+            },
+        }
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn redirect_uri(&mut self, redirect_uri: &'a str) -> &mut Self {
+        self.params.redirect_uri = Some(redirect_uri);
+        self
+    }
+
+    pub fn build(&self) -> OAuthClientUpdate<'a> {
+        OAuthClientUpdate {
+            client_id: self.client_id,
+            params: OAuthClientUpdateParams {
+                name: self.params.name,
+                redirect_uri: self.params.redirect_uri,
+            },
         }
     }
 }
@@ -28,21 +51,21 @@ impl OAuthClientUpdate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#oauth-client-update-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct OAuthClientUpdateParams {
+pub struct OAuthClientUpdateParams<'a> {
     /// OAuth client name
-    pub name: String,
+    pub name: Option<&'a str>,
     /// endpoint for redirection after authorization with OAuth client
-    pub redirect_uri: String,
+    pub redirect_uri: Option<&'a str>,
 }
 
-impl HerokuEndpoint<OAuthClient, (), OAuthClientUpdateParams> for OAuthClientUpdate {
+impl<'a> HerokuEndpoint<OAuthClient, (), OAuthClientUpdateParams<'a>> for OAuthClientUpdate<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("oauth/clients/{}", self.client_id)
     }
-    fn body(&self) -> Option<OAuthClientUpdateParams> {
+    fn body(&self) -> Option<OAuthClientUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/pipelines/delete.rs
+++ b/src/endpoints/pipelines/delete.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Delete an existing pipeline.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-delete)
-pub struct PipelineDelete {
+pub struct PipelineDelete<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl PipelineDelete {
-    pub fn new(pipeline_id: String) -> PipelineDelete {
+impl<'a> PipelineDelete<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineDelete<'a> {
         PipelineDelete { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<Pipeline, (), ()> for PipelineDelete {
+impl<'a> HerokuEndpoint<Pipeline> for PipelineDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }
@@ -33,18 +33,18 @@ impl HerokuEndpoint<Pipeline, (), ()> for PipelineDelete {
 /// Delete an existing pipeline coupling.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-delete)
-pub struct PipelineCouplingDelete {
+pub struct PipelineCouplingDelete<'a> {
     /// unique pipeline coupling identifier.
-    pub coupling_id: String,
+    pub coupling_id: &'a str,
 }
 
-impl PipelineCouplingDelete {
-    pub fn new(coupling_id: String) -> PipelineCouplingDelete {
+impl<'a> PipelineCouplingDelete<'a> {
+    pub fn new(coupling_id: &'a str) -> PipelineCouplingDelete<'a> {
         PipelineCouplingDelete { coupling_id }
     }
 }
 
-impl HerokuEndpoint<PipelineCoupling, (), ()> for PipelineCouplingDelete {
+impl<'a> HerokuEndpoint<PipelineCoupling> for PipelineCouplingDelete<'a> {
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/pipelines/get.rs
+++ b/src/endpoints/pipelines/get.rs
@@ -11,18 +11,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Info for existing pipeline.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-info)
-pub struct PipelineDetails {
+pub struct PipelineDetails<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl PipelineDetails {
-    pub fn new(pipeline_id: String) -> PipelineDetails {
+impl<'a> PipelineDetails<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineDetails<'a> {
         PipelineDetails { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<Pipeline> for PipelineDetails {
+impl<'a> HerokuEndpoint<Pipeline> for PipelineDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -58,18 +58,18 @@ impl HerokuEndpoint<Vec<Pipeline>> for PipelineList {
 /// List latest builds for each app in a pipeline
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-build-list)
-pub struct PipelineLatestBuildsList {
+pub struct PipelineLatestBuildsList<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl PipelineLatestBuildsList {
-    pub fn new(pipeline_id: String) -> PipelineLatestBuildsList {
+impl<'a> PipelineLatestBuildsList<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineLatestBuildsList<'a> {
         PipelineLatestBuildsList { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<Vec<PipelineBuild>> for PipelineLatestBuildsList {
+impl<'a> HerokuEndpoint<Vec<PipelineBuild>> for PipelineLatestBuildsList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -83,18 +83,18 @@ impl HerokuEndpoint<Vec<PipelineBuild>> for PipelineLatestBuildsList {
 /// List couplings for a pipeline
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-list-by-pipeline)
-pub struct PipelineCouplingByPipelineList {
+pub struct PipelineCouplingByPipelineList<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl PipelineCouplingByPipelineList {
-    pub fn new(pipeline_id: String) -> PipelineCouplingByPipelineList {
+impl<'a> PipelineCouplingByPipelineList<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineCouplingByPipelineList<'a> {
         PipelineCouplingByPipelineList { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<Vec<PipelineCoupling>> for PipelineCouplingByPipelineList {
+impl<'a> HerokuEndpoint<Vec<PipelineCoupling>> for PipelineCouplingByPipelineList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -130,18 +130,18 @@ impl HerokuEndpoint<Vec<PipelineCoupling>> for PipelineCouplingByUserList {
 /// List pipeline couplings for a team.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-list-by-team)
-pub struct PipelineCouplingByTeamList {
+pub struct PipelineCouplingByTeamList<'a> {
     /// unique team identifier.
-    pub team_id: String,
+    pub team_id: &'a str,
 }
 
-impl PipelineCouplingByTeamList {
-    pub fn new(team_id: String) -> PipelineCouplingByTeamList {
+impl<'a> PipelineCouplingByTeamList<'a> {
+    pub fn new(team_id: &'a str) -> PipelineCouplingByTeamList<'a> {
         PipelineCouplingByTeamList { team_id }
     }
 }
 
-impl HerokuEndpoint<Vec<PipelineCoupling>> for PipelineCouplingByTeamList {
+impl<'a> HerokuEndpoint<Vec<PipelineCoupling>> for PipelineCouplingByTeamList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -155,18 +155,18 @@ impl HerokuEndpoint<Vec<PipelineCoupling>> for PipelineCouplingByTeamList {
 /// Info for an existing pipeline coupling.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-info-by-app)
-pub struct PipelineCouplingByAppDetails {
+pub struct PipelineCouplingByAppDetails<'a> {
     /// unique app identifier.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl PipelineCouplingByAppDetails {
-    pub fn new(app_id: String) -> PipelineCouplingByAppDetails {
+impl<'a> PipelineCouplingByAppDetails<'a> {
+    pub fn new(app_id: &'a str) -> PipelineCouplingByAppDetails<'a> {
         PipelineCouplingByAppDetails { app_id }
     }
 }
 
-impl HerokuEndpoint<PipelineCoupling> for PipelineCouplingByAppDetails {
+impl<'a> HerokuEndpoint<PipelineCoupling> for PipelineCouplingByAppDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -202,18 +202,18 @@ impl HerokuEndpoint<Vec<PipelineCoupling>> for PipelineCouplingList {
 /// Info for an existing pipeline coupling.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-info)
-pub struct PipelineCouplingDetails {
+pub struct PipelineCouplingDetails<'a> {
     /// unique pipeline coupling identifier.
-    pub coupling_id: String,
+    pub coupling_id: &'a str,
 }
 
-impl PipelineCouplingDetails {
-    pub fn new(coupling_id: String) -> PipelineCouplingDetails {
+impl<'a> PipelineCouplingDetails<'a> {
+    pub fn new(coupling_id: &'a str) -> PipelineCouplingDetails<'a> {
         PipelineCouplingDetails { coupling_id }
     }
 }
 
-impl HerokuEndpoint<PipelineCoupling> for PipelineCouplingDetails {
+impl<'a> HerokuEndpoint<PipelineCoupling> for PipelineCouplingDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -227,18 +227,18 @@ impl HerokuEndpoint<PipelineCoupling> for PipelineCouplingDetails {
 /// List latest slug releases for each app in a pipeline
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-deployment-list)
-pub struct PipelineDeploymentList {
+pub struct PipelineDeploymentList<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl PipelineDeploymentList {
-    pub fn new(pipeline_id: String) -> PipelineDeploymentList {
+impl<'a> PipelineDeploymentList<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineDeploymentList<'a> {
         PipelineDeploymentList { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<Vec<PipelineDeployment>> for PipelineDeploymentList {
+impl<'a> HerokuEndpoint<Vec<PipelineDeployment>> for PipelineDeploymentList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -252,18 +252,18 @@ impl HerokuEndpoint<Vec<PipelineDeployment>> for PipelineDeploymentList {
 /// Info for existing pipeline promotion.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-promotion-info)
-pub struct PipelinePromotionDetails {
+pub struct PipelinePromotionDetails<'a> {
     /// unique pipeline identifier.
-    pub promotion_id: String,
+    pub promotion_id: &'a str,
 }
 
-impl PipelinePromotionDetails {
-    pub fn new(promotion_id: String) -> PipelinePromotionDetails {
+impl<'a> PipelinePromotionDetails<'a> {
+    pub fn new(promotion_id: &'a str) -> PipelinePromotionDetails<'a> {
         PipelinePromotionDetails { promotion_id }
     }
 }
 
-impl HerokuEndpoint<PipelinePromotion> for PipelinePromotionDetails {
+impl<'a> HerokuEndpoint<PipelinePromotion> for PipelinePromotionDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -277,18 +277,18 @@ impl HerokuEndpoint<PipelinePromotion> for PipelinePromotionDetails {
 /// List promotion targets belonging to an existing promotion.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-promotion-target-list)
-pub struct PipelinePromotionTargetList {
+pub struct PipelinePromotionTargetList<'a> {
     /// unique pipeline identifier.
-    pub promotion_id: String,
+    pub promotion_id: &'a str,
 }
 
-impl PipelinePromotionTargetList {
-    pub fn new(promotion_id: String) -> PipelinePromotionTargetList {
+impl<'a> PipelinePromotionTargetList<'a> {
+    pub fn new(promotion_id: &'a str) -> PipelinePromotionTargetList<'a> {
         PipelinePromotionTargetList { promotion_id }
     }
 }
 
-impl HerokuEndpoint<Vec<PipelinePromotionTarget>> for PipelinePromotionTargetList {
+impl<'a> HerokuEndpoint<Vec<PipelinePromotionTarget>> for PipelinePromotionTargetList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -305,18 +305,18 @@ impl HerokuEndpoint<Vec<PipelinePromotionTarget>> for PipelinePromotionTargetLis
 /// Information about latest releases of apps in a pipeline.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-release)
-pub struct PipelineLatestReleaseList {
+pub struct PipelineLatestReleaseList<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl PipelineLatestReleaseList {
-    pub fn new(pipeline_id: String) -> PipelineLatestReleaseList {
+impl<'a> PipelineLatestReleaseList<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineLatestReleaseList<'a> {
         PipelineLatestReleaseList { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<Vec<PipelineRelease>> for PipelineLatestReleaseList {
+impl<'a> HerokuEndpoint<Vec<PipelineRelease>> for PipelineLatestReleaseList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -330,18 +330,18 @@ impl HerokuEndpoint<Vec<PipelineRelease>> for PipelineLatestReleaseList {
 /// Information about latest releases of apps in a pipeline.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-release)
-pub struct PipelineStackDetails {
+pub struct PipelineStackDetails<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl PipelineStackDetails {
-    pub fn new(pipeline_id: String) -> PipelineStackDetails {
+impl<'a> PipelineStackDetails<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineStackDetails<'a> {
         PipelineStackDetails { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<PipelineStack> for PipelineStackDetails {
+impl<'a> HerokuEndpoint<PipelineStack> for PipelineStackDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/pipelines/patch.rs
+++ b/src/endpoints/pipelines/patch.rs
@@ -8,18 +8,32 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Update an existing pipeline.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-update)
-pub struct PipelineUpdate {
+pub struct PipelineUpdate<'a> {
     /// unique pipeline identifier.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: PipelineUpdateParams,
+    pub params: PipelineUpdateParams<'a>,
 }
 
-impl PipelineUpdate {
-    pub fn new(pipeline_id: String, name: Option<String>) -> PipelineUpdate {
+impl<'a> PipelineUpdate<'a> {
+    pub fn new(pipeline_id: &'a str) -> PipelineUpdate<'a> {
         PipelineUpdate {
             pipeline_id,
-            params: PipelineUpdateParams { name: name },
+            params: PipelineUpdateParams { name: None },
+        }
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn build(&self) -> PipelineUpdate<'a> {
+        PipelineUpdate {
+            pipeline_id: self.pipeline_id,
+            params: PipelineUpdateParams {
+                name: self.params.name,
+            },
         }
     }
 }
@@ -29,19 +43,19 @@ impl PipelineUpdate {
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-update-optional-parameters)
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct PipelineUpdateParams {
+pub struct PipelineUpdateParams<'a> {
     /// name of pipeline. pattern: ^[a-z][a-z0-9-]{2,29}$
-    pub name: Option<String>,
+    pub name: Option<&'a str>,
 }
 
-impl HerokuEndpoint<Pipeline, (), PipelineUpdateParams> for PipelineUpdate {
+impl<'a> HerokuEndpoint<Pipeline, (), PipelineUpdateParams<'a>> for PipelineUpdate<'a> {
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("pipelines/{}", self.pipeline_id)
     }
-    fn body(&self) -> Option<PipelineUpdateParams> {
+    fn body(&self) -> Option<PipelineUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -51,18 +65,32 @@ impl HerokuEndpoint<Pipeline, (), PipelineUpdateParams> for PipelineUpdate {
 /// Update an existing pipeline coupling.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-update)
-pub struct PipelineCouplingUpdate {
+pub struct PipelineCouplingUpdate<'a> {
     /// unique pipeline coupling identifier.
-    pub coupling_id: String,
+    pub coupling_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: PipelineCouplingUpdateParams,
+    pub params: PipelineCouplingUpdateParams<'a>,
 }
 
-impl PipelineCouplingUpdate {
-    pub fn new(coupling_id: String, stage: String) -> PipelineCouplingUpdate {
+impl<'a> PipelineCouplingUpdate<'a> {
+    pub fn new(coupling_id: &'a str) -> PipelineCouplingUpdate {
         PipelineCouplingUpdate {
             coupling_id,
-            params: PipelineCouplingUpdateParams { stage },
+            params: PipelineCouplingUpdateParams { stage: None },
+        }
+    }
+
+    pub fn stage(&mut self, stage: &'a str) -> &mut Self {
+        self.params.stage = Some(stage);
+        self
+    }
+
+    pub fn build(&self) -> PipelineCouplingUpdate<'a> {
+        PipelineCouplingUpdate {
+            coupling_id: self.coupling_id,
+            params: PipelineCouplingUpdateParams {
+                stage: self.params.stage,
+            },
         }
     }
 }
@@ -71,19 +99,21 @@ impl PipelineCouplingUpdate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-update-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct PipelineCouplingUpdateParams {
+pub struct PipelineCouplingUpdateParams<'a> {
     /// target pipeline stage. one of:"test" or "review" or "development" or "staging" or "production"
-    pub stage: String,
+    pub stage: Option<&'a str>,
 }
 
-impl HerokuEndpoint<PipelineCoupling, (), PipelineCouplingUpdateParams> for PipelineCouplingUpdate {
+impl<'a> HerokuEndpoint<PipelineCoupling, (), PipelineCouplingUpdateParams<'a>>
+    for PipelineCouplingUpdate<'a>
+{
     fn method(&self) -> Method {
         Method::Patch
     }
     fn path(&self) -> String {
         format!("pipeline-couplings/{}", self.coupling_id)
     }
-    fn body(&self) -> Option<PipelineCouplingUpdateParams> {
+    fn body(&self) -> Option<PipelineCouplingUpdateParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/pipelines/post.rs
+++ b/src/endpoints/pipelines/post.rs
@@ -8,13 +8,13 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Create a new pipeline.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-create)
-pub struct PipelineCreate {
+pub struct PipelineCreate<'a> {
     /// The parameters to pass to the Heroku API
-    pub params: PipelineCreateParams,
+    pub params: PipelineCreateParams<'a>,
 }
 
-impl PipelineCreate {
-    pub fn new(pipeline_name: String) -> PipelineCreate {
+impl<'a> PipelineCreate<'a> {
+    pub fn new(pipeline_name: &'a str) -> PipelineCreate<'a> {
         PipelineCreate {
             params: PipelineCreateParams {
                 name: pipeline_name,
@@ -27,19 +27,19 @@ impl PipelineCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-create-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct PipelineCreateParams {
+pub struct PipelineCreateParams<'a> {
     /// name of pipeline. pattern: ^[a-z][a-z0-9-]{2,29}$
-    pub name: String,
+    pub name: &'a str,
 }
 
-impl HerokuEndpoint<Pipeline, (), PipelineCreateParams> for PipelineCreate {
+impl<'a> HerokuEndpoint<Pipeline, (), PipelineCreateParams<'a>> for PipelineCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("pipelines")
     }
-    fn body(&self) -> Option<PipelineCreateParams> {
+    fn body(&self) -> Option<PipelineCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -49,17 +49,17 @@ impl HerokuEndpoint<Pipeline, (), PipelineCreateParams> for PipelineCreate {
 /// Create a new pipeline coupling.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-create)
-pub struct PipelineCouplingCreate {
+pub struct PipelineCouplingCreate<'a> {
     /// The parameters to pass to the Heroku API
-    pub params: PipelineCouplingCreateParams,
+    pub params: PipelineCouplingCreateParams<'a>,
 }
 
-impl PipelineCouplingCreate {
+impl<'a> PipelineCouplingCreate<'a> {
     pub fn new(
-        app_id: String,
-        pipeline_id: String,
-        pipeline_stage: String,
-    ) -> PipelineCouplingCreate {
+        app_id: &'a str,
+        pipeline_id: &'a str,
+        pipeline_stage: &'a str,
+    ) -> PipelineCouplingCreate<'a> {
         PipelineCouplingCreate {
             params: PipelineCouplingCreateParams {
                 app: app_id,
@@ -74,45 +74,45 @@ impl PipelineCouplingCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-coupling-create-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct PipelineCouplingCreateParams {
+pub struct PipelineCouplingCreateParams<'a> {
     /// unique identifier or name of app
-    pub app: String,
+    pub app: &'a str,
     /// unique identifier of pipeline
-    pub pipeline: String,
+    pub pipeline: &'a str,
     /// target pipeline stage. one of:"test" or "review" or "development" or "staging" or "production"
-    pub stage: String,
+    pub stage: &'a str,
 }
 
-impl HerokuEndpoint<PipelineCoupling, (), PipelineCouplingCreateParams> for PipelineCouplingCreate {
+impl<'a> HerokuEndpoint<PipelineCoupling, (), PipelineCouplingCreateParams<'a>>
+    for PipelineCouplingCreate<'a>
+{
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("pipeline-couplings")
     }
-    fn body(&self) -> Option<PipelineCouplingCreateParams> {
+    fn body(&self) -> Option<PipelineCouplingCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
 
-///
-///
 /// Pipeline Promotion Create
 ///
 /// Create a new promotion.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-promotion-create)
-pub struct PipelinePromotionCreate {
+pub struct PipelinePromotionCreate<'a> {
     /// The parameters to pass to the Heroku API
-    pub params: PipelinePromotionCreateParams,
+    pub params: PipelinePromotionCreateParams<'a>,
 }
 
-impl PipelinePromotionCreate {
+impl<'a> PipelinePromotionCreate<'a> {
     pub fn new(
-        pipeline_id: String,
-        source_app_id: String,
-        target_app_id: String,
-    ) -> PipelinePromotionCreate {
+        pipeline_id: &'a str,
+        source_app_id: &'a str,
+        target_app_id: &'a str,
+    ) -> PipelinePromotionCreate<'a> {
         PipelinePromotionCreate {
             params: PipelinePromotionCreateParams {
                 pipeline: PipelineParam { id: pipeline_id },
@@ -131,52 +131,34 @@ impl PipelinePromotionCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-promotion-create-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct PipelinePromotionCreateParams {
-    pub pipeline: PipelineParam,
-    pub source: SourceParam,
-    pub targets: Vec<TargetParam>,
-}
-
-impl PipelinePromotionCreateParams {
-    pub fn new(
-        pipeline_id: String,
-        source_app_id: String,
-        target_app_id: String,
-    ) -> PipelinePromotionCreateParams {
-        Self {
-            pipeline: PipelineParam { id: pipeline_id },
-            source: SourceParam {
-                app: AppParam { id: source_app_id },
-            },
-            targets: vec![TargetParam {
-                app: AppParam { id: target_app_id },
-            }],
-        }
-    }
+pub struct PipelinePromotionCreateParams<'a> {
+    pub pipeline: PipelineParam<'a>,
+    pub source: SourceParam<'a>,
+    pub targets: Vec<TargetParam<'a>>,
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub struct PipelineParam {
-    pub id: String,
+pub struct PipelineParam<'a> {
+    pub id: &'a str,
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub struct SourceParam {
-    pub app: AppParam,
+pub struct SourceParam<'a> {
+    pub app: AppParam<'a>,
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub struct AppParam {
-    pub id: String,
+pub struct AppParam<'a> {
+    pub id: &'a str,
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub struct TargetParam {
-    pub app: AppParam,
+pub struct TargetParam<'a> {
+    pub app: AppParam<'a>,
 }
 
-impl HerokuEndpoint<PipelinePromotion, (), PipelinePromotionCreateParams>
-    for PipelinePromotionCreate
+impl<'a> HerokuEndpoint<PipelinePromotion, (), PipelinePromotionCreateParams<'a>>
+    for PipelinePromotionCreate<'a>
 {
     fn method(&self) -> Method {
         Method::Post
@@ -184,7 +166,7 @@ impl HerokuEndpoint<PipelinePromotion, (), PipelinePromotionCreateParams>
     fn path(&self) -> String {
         format!("pipeline-promotions")
     }
-    fn body(&self) -> Option<PipelinePromotionCreateParams> {
+    fn body(&self) -> Option<PipelinePromotionCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -194,16 +176,16 @@ impl HerokuEndpoint<PipelinePromotion, (), PipelinePromotionCreateParams>
 /// A pipeline transfer is the process of changing pipeline ownership along with the contained apps.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-transfer)
-pub struct PipelineTransferCreate {
-    pub params: PipelineTransferCreateParams,
+pub struct PipelineTransferCreate<'a> {
+    pub params: PipelineTransferCreateParams<'a>,
 }
 
-impl PipelineTransferCreate {
+impl<'a> PipelineTransferCreate<'a> {
     pub fn new(
-        pipeline_id: String,
-        new_owner_id: String,
-        new_owner_type: String,
-    ) -> PipelineTransferCreate {
+        pipeline_id: &'a str,
+        new_owner_id: &'a str,
+        new_owner_type: &'a str,
+    ) -> PipelineTransferCreate<'a> {
         PipelineTransferCreate {
             params: PipelineTransferCreateParams {
                 pipeline: PipelineParam { id: pipeline_id },
@@ -220,44 +202,31 @@ impl PipelineTransferCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#pipeline-transfer-create-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct PipelineTransferCreateParams {
-    pub pipeline: PipelineParam,
-    pub new_owner: NewOwner,
+pub struct PipelineTransferCreateParams<'a> {
+    pub pipeline: PipelineParam<'a>,
+    pub new_owner: NewOwner<'a>,
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub struct NewOwner {
+pub struct NewOwner<'a> {
     /// unique identifier of a pipeline owner
-    pub id: String,
+    pub id: &'a str,
     /// type of pipeline owner
     /// pattern: `(^team$
     #[serde(rename = "type")]
-    pub type_field: String,
+    pub type_field: &'a str,
 }
 
-impl PipelineTransferCreateParams {
-    pub fn new(
-        pipeline_id: String,
-        new_owner_id: String,
-        new_owner_type: String,
-    ) -> PipelineTransferCreateParams {
-        Self {
-            pipeline: PipelineParam { id: pipeline_id },
-            new_owner: NewOwner {
-                id: new_owner_id,
-                type_field: new_owner_type,
-            },
-        }
-    }
-}
-impl HerokuEndpoint<PipelineTransfer, (), PipelineTransferCreateParams> for PipelineTransferCreate {
+impl<'a> HerokuEndpoint<PipelineTransfer, (), PipelineTransferCreateParams<'a>>
+    for PipelineTransferCreate<'a>
+{
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("pipeline-transfers")
     }
-    fn body(&self) -> Option<PipelineTransferCreateParams> {
+    fn body(&self) -> Option<PipelineTransferCreateParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/releases/get.rs
+++ b/src/endpoints/releases/get.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 ///
 /// List existing releases
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#release-list)
-pub struct ReleaseList {
+pub struct ReleaseList<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl ReleaseList {
-    pub fn new(app_id: String) -> ReleaseList {
+impl<'a> ReleaseList<'a> {
+    pub fn new(app_id: &'a str) -> ReleaseList<'a> {
         ReleaseList { app_id }
     }
 }
 
-impl HerokuEndpoint<Vec<Release>> for ReleaseList {
+impl<'a> HerokuEndpoint<Vec<Release>> for ReleaseList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -32,20 +32,20 @@ impl HerokuEndpoint<Vec<Release>> for ReleaseList {
 ///
 /// Info for existing release
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#release-info)
-pub struct ReleaseInfo {
+pub struct ReleaseInfo<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// release_id can be the id or version
-    pub release_id: String,
+    pub release_id: &'a str,
 }
 
-impl ReleaseInfo {
-    pub fn new(app_id: String, release_id: String) -> ReleaseInfo {
+impl<'a> ReleaseInfo<'a> {
+    pub fn new(app_id: &'a str, release_id: &'a str) -> ReleaseInfo<'a> {
         ReleaseInfo { app_id, release_id }
     }
 }
 
-impl HerokuEndpoint<Release> for ReleaseInfo {
+impl<'a> HerokuEndpoint<Release> for ReleaseInfo<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/releases/post.rs
+++ b/src/endpoints/releases/post.rs
@@ -9,27 +9,35 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#release-create)
 #[derive(Serialize)]
-pub struct ReleaseCreate {
+pub struct ReleaseCreate<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: ReleaseCreateParams,
+    pub params: ReleaseCreateParams<'a>,
 }
 
-impl ReleaseCreate {
-    pub fn new(app_id: String, slug: String, description: Option<String>) -> ReleaseCreate {
-        ReleaseCreate {
-            app_id,
-            params: ReleaseCreateParams { slug, description },
-        }
-    }
-
-    pub fn create(app_id: String, slug: String) -> ReleaseCreate {
+impl<'a> ReleaseCreate<'a> {
+    pub fn new(app_id: &'a str, slug: &'a str) -> ReleaseCreate<'a> {
         ReleaseCreate {
             app_id,
             params: ReleaseCreateParams {
                 slug: slug,
                 description: None,
+            },
+        }
+    }
+
+    pub fn description(&mut self, description: &'a str) -> &mut Self {
+        self.params.description = Some(description);
+        self
+    }
+
+    pub fn build(&self) -> ReleaseCreate<'a> {
+        ReleaseCreate {
+            app_id: self.app_id,
+            params: ReleaseCreateParams {
+                slug: self.params.slug,
+                description: self.params.description,
             },
         }
     }
@@ -42,21 +50,21 @@ impl ReleaseCreate {
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#release-create-required-parameters)
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug)]
-pub struct ReleaseCreateParams {
+pub struct ReleaseCreateParams<'a> {
     /// unique identifier of slug
-    pub slug: String,
+    pub slug: &'a str,
     /// description of changes in release
-    pub description: Option<String>,
+    pub description: Option<&'a str>,
 }
 
-impl HerokuEndpoint<Release, (), ReleaseCreateParams> for ReleaseCreate {
+impl<'a> HerokuEndpoint<Release, (), ReleaseCreateParams<'a>> for ReleaseCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps/{}/releases", self.app_id)
     }
-    fn body(&self) -> Option<ReleaseCreateParams> {
+    fn body(&self) -> Option<ReleaseCreateParams<'a>> {
         Some(self.params.clone())
     }
 }
@@ -67,15 +75,15 @@ impl HerokuEndpoint<Release, (), ReleaseCreateParams> for ReleaseCreate {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#release-rollback)
 #[derive(Serialize)]
-pub struct ReleaseRollback {
+pub struct ReleaseRollback<'a> {
     /// app_id can be the app name or the app id
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: ReleaseRollbackParams,
+    pub params: ReleaseRollbackParams<'a>,
 }
 
-impl ReleaseRollback {
-    pub fn new(app_id: String, release_id: String) -> ReleaseRollback {
+impl<'a> ReleaseRollback<'a> {
+    pub fn new(app_id: &'a str, release_id: &'a str) -> ReleaseRollback<'a> {
         ReleaseRollback {
             app_id,
             params: ReleaseRollbackParams {
@@ -91,19 +99,19 @@ impl ReleaseRollback {
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#release-rollback-required-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct ReleaseRollbackParams {
+pub struct ReleaseRollbackParams<'a> {
     /// unique identifier of release
-    pub release: String,
+    pub release: &'a str,
 }
 
-impl HerokuEndpoint<Release, (), ReleaseRollbackParams> for ReleaseRollback {
+impl<'a> HerokuEndpoint<Release, (), ReleaseRollbackParams<'a>> for ReleaseRollback<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps/{}/releases", self.app_id)
     }
-    fn body(&self) -> Option<ReleaseRollbackParams> {
+    fn body(&self) -> Option<ReleaseRollbackParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/review/delete.rs
+++ b/src/endpoints/review/delete.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Delete an existing review app
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#review-app-delete)
-pub struct ReviewAppDelete {
+pub struct ReviewAppDelete <'a>{
     /// review_id is the unique identifier.
-    pub review_id: String,
+    pub review_id: &'a str,
 }
 
-impl ReviewAppDelete {
-    pub fn new(review_id: String) -> ReviewAppDelete {
+impl<'a> ReviewAppDelete <'a>{
+    pub fn new(review_id: &'a str) -> ReviewAppDelete <'a>{
         ReviewAppDelete { review_id }
     }
 }
 
-impl HerokuEndpoint<ReviewApp> for ReviewAppDelete {
+impl<'a> HerokuEndpoint<ReviewApp> for ReviewAppDelete <'a>{
     fn method(&self) -> Method {
         Method::Delete
     }

--- a/src/endpoints/review/get.rs
+++ b/src/endpoints/review/get.rs
@@ -8,18 +8,18 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Gets an existing review app
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#review-app-get-review-app)
-pub struct ReviewAppDetails {
+pub struct ReviewAppDetails<'a> {
     /// review_id is the unique identifier.
-    pub review_id: String,
+    pub review_id: &'a str,
 }
 
-impl ReviewAppDetails {
-    pub fn new(review_id: String) -> ReviewAppDetails {
+impl <'a>ReviewAppDetails <'a>{
+    pub fn new(review_id: &'a str) -> ReviewAppDetails <'a>{
         ReviewAppDetails { review_id }
     }
 }
 
-impl HerokuEndpoint<ReviewApp> for ReviewAppDetails {
+impl <'a>HerokuEndpoint<ReviewApp> for ReviewAppDetails <'a>{
     fn method(&self) -> Method {
         Method::Get
     }
@@ -33,18 +33,18 @@ impl HerokuEndpoint<ReviewApp> for ReviewAppDetails {
 /// Get a review app using the associated app_id
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#review-app-get-review-app-by-app_id)
-pub struct ReviewAppByAppDetails {
+pub struct ReviewAppByAppDetails<'a> {
     /// app_id is the unique identifier, app name or app id.
-    pub app_id: String,
+    pub app_id: &'a str,
 }
 
-impl ReviewAppByAppDetails {
-    pub fn new(app_id: String) -> ReviewAppByAppDetails {
+impl <'a>ReviewAppByAppDetails<'a> {
+    pub fn new(app_id: &'a str) -> ReviewAppByAppDetails<'a> {
         ReviewAppByAppDetails { app_id }
     }
 }
 
-impl HerokuEndpoint<ReviewApp> for ReviewAppByAppDetails {
+impl <'a>HerokuEndpoint<ReviewApp> for ReviewAppByAppDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }
@@ -58,18 +58,18 @@ impl HerokuEndpoint<ReviewApp> for ReviewAppByAppDetails {
 /// List review apps for a pipeline
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#review-app-list)
-pub struct ReviewAppByPipelineList {
+pub struct ReviewAppByPipelineList<'a> {
     /// app_id is the unique identifier, app name or app id.
-    pub pipeline_id: String,
+    pub pipeline_id: &'a str,
 }
 
-impl ReviewAppByPipelineList {
-    pub fn new(pipeline_id: String) -> ReviewAppByPipelineList {
+impl<'a> ReviewAppByPipelineList<'a> {
+    pub fn new(pipeline_id: &'a str) -> ReviewAppByPipelineList <'a>{
         ReviewAppByPipelineList { pipeline_id }
     }
 }
 
-impl HerokuEndpoint<Vec<ReviewApp>> for ReviewAppByPipelineList {
+impl<'a> HerokuEndpoint<Vec<ReviewApp>> for ReviewAppByPipelineList<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/review/patch.rs
+++ b/src/endpoints/review/patch.rs
@@ -15,35 +15,63 @@ pub struct ReviewAppConfigUpdate<'a> {
 }
 
 impl<'a> ReviewAppConfigUpdate<'a> {
-    pub fn new(
-        pipeline_id: &'a str,
-        automatic_review_apps: Option<bool>,
-        destroy_stale_apps: Option<bool>,
-        stale_days: Option<&'a str>,
-        deploy_target_id: Option<&'a str>,
-        deploy_target_type: Option<&'a str>,
-        wait_for_ci: Option<bool>,
-        base_name: Option<&'a str>,
-    ) -> ReviewAppConfigUpdate<'a> {
-        // tl;dr DeployTarget is nullable in the API and both fields should either provided or not.
-        let deploy_type: Option<DeployTarget> = match (deploy_target_id, deploy_target_type) {
-            (Some(target_id), Some(type_id)) => Some(DeployTarget {
-                id: target_id,
-                type_field: type_id
-            }),
-            (None, None) =>  None,
-            _ => panic!("deploy_target_id and deploy_target_type have to be either both Some or both None, but not in-between!"),
-        };
-
+    pub fn new(pipeline_id: &'a str) -> ReviewAppConfigUpdate<'a> {
         ReviewAppConfigUpdate {
             pipeline_id,
             params: ReviewAppConfigUpdateParams {
-                automatic_review_apps: automatic_review_apps,
-                destroy_stale_apps: destroy_stale_apps,
-                stale_days: stale_days,
-                deploy_target: deploy_type,
-                wait_for_ci: wait_for_ci,
-                base_name: base_name,
+                automatic_review_apps: None,
+                destroy_stale_apps: None,
+                stale_days: None,
+                deploy_target: None,
+                wait_for_ci: None,
+                base_name: None,
+            },
+        }
+    }
+
+    pub fn base_name(&mut self, base_name: &'a str) -> &mut Self {
+        self.params.base_name = Some(base_name);
+        self
+    }
+
+    pub fn wait_for_ci(&mut self, wait_for_ci: bool) -> &mut Self {
+        self.params.wait_for_ci = Some(wait_for_ci);
+        self
+    }
+
+    pub fn deploy_target(&mut self, id: &'a str, t_type: &'a str) -> &mut Self {
+        self.params.deploy_target = Some(DeployTarget {
+            id: id,
+            type_field: t_type,
+        });
+        self
+    }
+
+    pub fn stale_days(&mut self, stale_days: &'a str) -> &mut Self {
+        self.params.stale_days = Some(stale_days);
+        self
+    }
+
+    pub fn destroy_stale_apps(&mut self, destroy_stale_apps: bool) -> &mut Self {
+        self.params.destroy_stale_apps = Some(destroy_stale_apps);
+        self
+    }
+
+    pub fn automatic_review_apps(&mut self, automatic_review_apps: bool) -> &mut Self {
+        self.params.automatic_review_apps = Some(automatic_review_apps);
+        self
+    }
+
+    pub fn build(&self) -> ReviewAppConfigUpdate<'a> {
+        ReviewAppConfigUpdate {
+            pipeline_id: self.pipeline_id,
+            params: ReviewAppConfigUpdateParams {
+                automatic_review_apps: self.params.automatic_review_apps,
+                destroy_stale_apps: self.params.destroy_stale_apps,
+                stale_days: self.params.stale_days,
+                deploy_target: self.params.deploy_target.clone(),
+                wait_for_ci: self.params.wait_for_ci,
+                base_name: self.params.base_name,
             },
         }
     }

--- a/src/endpoints/slugs/get.rs
+++ b/src/endpoints/slugs/get.rs
@@ -8,20 +8,20 @@ use crate::framework::endpoint::{HerokuEndpoint, Method};
 /// Info for existing slug.
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#slug-info)
-pub struct SlugDetails {
+pub struct SlugDetails<'a> {
     /// unique app identifier.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// unique slug indentifier.
-    pub slug_id: String,
+    pub slug_id: &'a str,
 }
 
-impl SlugDetails {
-    pub fn new(app_id: String, slug_id: String) -> SlugDetails {
+impl<'a> SlugDetails<'a> {
+    pub fn new(app_id: &'a str, slug_id: &'a str) -> SlugDetails<'a> {
         SlugDetails { app_id, slug_id }
     }
 }
 
-impl HerokuEndpoint<Slug> for SlugDetails {
+impl<'a> HerokuEndpoint<Slug> for SlugDetails<'a> {
     fn method(&self) -> Method {
         Method::Get
     }

--- a/src/endpoints/slugs/post.rs
+++ b/src/endpoints/slugs/post.rs
@@ -9,37 +9,15 @@ use std::collections::HashMap;
 /// Create a new slug. For more information please refer to ]Deploying Slugs using the Platform API.](https://devcenter.heroku.com/articles/platform-api-deploying-slugs)
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#slug-create)
-pub struct SlugCreate {
+pub struct SlugCreate<'a> {
     /// app_id is the unique app identifier.
-    pub app_id: String,
+    pub app_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params: SlugCreateParams,
+    pub params: SlugCreateParams<'a>,
 }
 
-impl SlugCreate {
-    pub fn new(
-        app_id: String,
-        process_types: HashMap<String, String>,
-        buildpack_provided_description: Option<String>,
-        checksum: Option<String>,
-        commit: Option<String>,
-        commit_description: Option<String>,
-        stack: Option<String>,
-    ) -> SlugCreate {
-        SlugCreate {
-            app_id,
-            params: SlugCreateParams {
-                process_types,
-                buildpack_provided_description,
-                checksum,
-                commit,
-                commit_description,
-                stack,
-            },
-        }
-    }
-
-    pub fn create(app_id: String, process_types: HashMap<String, String>) -> SlugCreate {
+impl<'a> SlugCreate<'a> {
+    pub fn new(app_id: &'a str, process_types: HashMap<&'a str, &'a str>) -> SlugCreate<'a> {
         SlugCreate {
             app_id,
             params: SlugCreateParams {
@@ -52,6 +30,48 @@ impl SlugCreate {
             },
         }
     }
+
+    pub fn buildpack_provided_description(
+        &mut self,
+        buildpack_provided_description: &'a str,
+    ) -> &mut Self {
+        self.params.buildpack_provided_description = Some(buildpack_provided_description);
+        self
+    }
+
+    pub fn checksum(&mut self, checksum: &'a str) -> &mut Self {
+        self.params.checksum = Some(checksum);
+        self
+    }
+
+    pub fn commit(&mut self, commit: &'a str) -> &mut Self {
+        self.params.commit = Some(commit);
+        self
+    }
+
+    pub fn commit_description(&mut self, commit_description: &'a str) -> &mut Self {
+        self.params.commit_description = Some(commit_description);
+        self
+    }
+
+    pub fn stack(&mut self, stack: &'a str) -> &mut Self {
+        self.params.stack = Some(stack);
+        self
+    }
+
+    pub fn build(&self) -> SlugCreate<'a> {
+        SlugCreate {
+            app_id: self.app_id,
+            params: SlugCreateParams {
+                process_types: self.params.process_types.clone(),
+                buildpack_provided_description: self.params.buildpack_provided_description,
+                checksum: self.params.checksum,
+                commit: self.params.commit,
+                commit_description: self.params.commit_description,
+                stack: self.params.stack,
+            },
+        }
+    }
 }
 
 /// Create a new slug with parameters.
@@ -60,30 +80,30 @@ impl SlugCreate {
 ///
 /// [See Heroku documentation for more information about these optional parameters](https://devcenter.heroku.com/articles/platform-api-reference#slug-create-optional-parameters)
 #[derive(Serialize, Clone, Debug)]
-pub struct SlugCreateParams {
+pub struct SlugCreateParams<'a> {
     /// hash mapping process type names to their respective command. [Nullable]
-    pub process_types: HashMap<String, String>,
+    pub process_types: HashMap<&'a str, &'a str>,
     /// human-friendly description from buildpack of slug. [Nullable]
-    pub buildpack_provided_description: Option<String>,
+    pub buildpack_provided_description: Option<&'a str>,
     //// an optional checksum of the slug for verifying its integrity. [Nullable]
-    pub checksum: Option<String>,
+    pub checksum: Option<&'a str>,
     /// identification of the code with your version control system (eg: SHA of the git HEAD). [Nullable]
-    pub commit: Option<String>,
+    pub commit: Option<&'a str>,
     /// an optional description of the provided commit. [Nullable]
-    pub commit_description: Option<String>,
+    pub commit_description: Option<&'a str>,
     /// unique name or identifier of stack
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stack: Option<String>,
+    pub stack: Option<&'a str>,
 }
 
-impl HerokuEndpoint<Slug, (), SlugCreateParams> for SlugCreate {
+impl<'a> HerokuEndpoint<Slug, (), SlugCreateParams<'a>> for SlugCreate<'a> {
     fn method(&self) -> Method {
         Method::Post
     }
     fn path(&self) -> String {
         format!("apps/{}/slugs", self.app_id)
     }
-    fn body(&self) -> Option<SlugCreateParams> {
+    fn body(&self) -> Option<SlugCreateParams<'a>> {
         Some(self.params.clone())
     }
 }

--- a/src/endpoints/teams/mod.rs
+++ b/src/endpoints/teams/mod.rs
@@ -20,8 +20,7 @@ pub use patch::{
 };
 pub use post::{
     TeamAppCreate, TeamAppCreateParams, TeamCreate, TeamCreateByEA, TeamCreateByEAParams,
-    TeamCreateOptionalParams, TeamCreateParams, TeamInvitationAccept, TeamMemberCreate,
-    TeamMemberCreateParams,
+    TeamCreateParams, TeamInvitationAccept, TeamMemberCreate, TeamMemberCreateParams,
 };
 pub use put::{
     TeamInvitationCreate, TeamInvitationCreateParams, TeamMemberCreateorUpdate,

--- a/src/endpoints/teams/patch.rs
+++ b/src/endpoints/teams/patch.rs
@@ -12,26 +12,38 @@ pub struct TeamUpdate<'a> {
     /// team_id is the unique team identifier.
     pub team_id: &'a str,
     /// The parameters to pass to the Heroku API
-    pub params_optional: Option<TeamUpdateParams<'a>>,
+    pub params: TeamUpdateParams<'a>,
 }
 
 impl<'a> TeamUpdate<'a> {
     // cares for optional parameters
-    pub fn new(team_id: &'a str, default: Option<bool>, name: Option<&'a str>) -> TeamUpdate<'a> {
+    pub fn new(team_id: &'a str) -> TeamUpdate<'a> {
         TeamUpdate {
             team_id,
-            params_optional: Some(TeamUpdateParams {
-                default: default,
-                name: name,
-            }),
+            params: TeamUpdateParams {
+                default: None,
+                name: None,
+            },
         }
     }
 
-    // only required parameters to be passed
-    pub fn create(team_id: &'a str) -> TeamUpdate<'a> {
+    pub fn default(&mut self, default: bool) -> &mut Self {
+        self.params.default = Some(default);
+        self
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn build(&self) -> TeamUpdate<'a> {
         TeamUpdate {
-            team_id,
-            params_optional: None,
+            team_id: self.team_id,
+            params: TeamUpdateParams {
+                default: self.params.default,
+                name: self.params.name,
+            },
         }
     }
 }
@@ -56,7 +68,7 @@ impl<'a> HerokuEndpoint<Team, (), TeamUpdateParams<'a>> for TeamUpdate<'a> {
         format!("teams/{}", self.team_id)
     }
     fn body(&self) -> Option<TeamUpdateParams<'a>> {
-        self.params_optional.clone()
+        Some(self.params.clone())
     }
 }
 
@@ -166,30 +178,30 @@ pub struct TeamMemberUpdate<'a> {
 }
 
 impl<'a> TeamMemberUpdate<'a> {
-    /// required and optional parameters
-    pub fn new(
-        team_id: &'a str,
-        email: &'a str,
-        role: &'a str,
-        federated: Option<bool>,
-    ) -> TeamMemberUpdate<'a> {
-        TeamMemberUpdate {
-            team_id,
-            params: TeamMemberUpdateParams {
-                email,
-                role,
-                federated,
-            },
-        }
-    }
     /// Only required parameters passed
-    pub fn create(team_id: &'a str, email: &'a str, role: &'a str) -> TeamMemberUpdate<'a> {
+    pub fn new(team_id: &'a str, email: &'a str, role: &'a str) -> TeamMemberUpdate<'a> {
         TeamMemberUpdate {
             team_id,
             params: TeamMemberUpdateParams {
                 email: email,
                 role: role,
                 federated: None,
+            },
+        }
+    }
+
+    pub fn federated(&mut self, federated: bool) -> &mut Self {
+        self.params.federated = Some(federated);
+        self
+    }
+
+    pub fn build(&self) -> TeamMemberUpdate<'a> {
+        TeamMemberUpdate {
+            team_id: self.team_id,
+            params: TeamMemberUpdateParams {
+                email: self.params.email,
+                role: self.params.role,
+                federated: self.params.federated,
             },
         }
     }
@@ -236,11 +248,25 @@ pub struct TeamPreferenceUpdate<'a> {
 }
 
 impl<'a> TeamPreferenceUpdate<'a> {
-    pub fn new(id: &'a str, whitelisting_enabled: Option<bool>) -> TeamPreferenceUpdate<'a> {
+    pub fn new(id: &'a str) -> TeamPreferenceUpdate<'a> {
         TeamPreferenceUpdate {
             id,
             params: TeamPreferenceUpdateParams {
-                whitelisting_enabled,
+                whitelisting_enabled: None,
+            },
+        }
+    }
+
+    pub fn whitelisting_enabled(&mut self, whitelisting_enabled: bool) -> &mut Self {
+        self.params.whitelisting_enabled = Some(whitelisting_enabled);
+        self
+    }
+
+    pub fn build(&self) -> TeamPreferenceUpdate<'a> {
+        TeamPreferenceUpdate {
+            id: self.id,
+            params: TeamPreferenceUpdateParams {
+                whitelisting_enabled: self.params.whitelisting_enabled,
             },
         }
     }

--- a/src/endpoints/teams/post.rs
+++ b/src/endpoints/teams/post.rs
@@ -13,55 +13,123 @@ pub struct TeamCreate<'a> {
 }
 
 impl<'a> TeamCreate<'a> {
-    // `new` method has the required parameters & optional ones
-    pub fn new(
-        name: &'a str,
-        address_1: Option<&'a str>,
-        address_2: Option<&'a str>,
-        card_number: Option<&'a str>,
-        city: Option<&'a str>,
-        country: Option<&'a str>,
-        cvv: Option<&'a str>,
-        expiration_month: Option<&'a str>,
-        expiration_year: Option<&'a str>,
-        first_name: Option<&'a str>,
-        last_name: Option<&'a str>,
-        other: Option<&'a str>,
-        postal_code: Option<&'a str>,
-        state: Option<&'a str>,
-        nonce: Option<&'a str>,
-        device_data: Option<&'a str>,
-    ) -> TeamCreate<'a> {
+    // `new` method has only the required parameters
+    pub fn new(name: &'a str) -> TeamCreate {
         TeamCreate {
             params: TeamCreateParams {
-                name,
-                params_optional: Some(TeamCreateOptionalParams {
-                    address_1,
-                    address_2,
-                    card_number,
-                    city,
-                    country,
-                    cvv,
-                    expiration_month,
-                    expiration_year,
-                    first_name,
-                    last_name,
-                    other,
-                    postal_code,
-                    state,
-                    nonce,
-                    device_data,
-                }),
+                name: name,
+                address_1: None,
+                address_2: None,
+                card_number: None,
+                city: None,
+                country: None,
+                cvv: None,
+                expiration_month: None,
+                expiration_year: None,
+                first_name: None,
+                last_name: None,
+                other: None,
+                postal_code: None,
+                state: None,
+                nonce: None,
+                device_data: None,
             },
         }
     }
 
-    // `create` method has only the required parameters
-    pub fn create(name: &'a str) -> TeamCreate {
+    pub fn address_1(&mut self, address_1: &'a str) -> &mut Self {
+        self.params.address_1 = Some(address_1);
+        self
+    }
+
+    pub fn address_2(&mut self, address_2: &'a str) -> &mut Self {
+        self.params.address_2 = Some(address_2);
+        self
+    }
+
+    pub fn card_number(&mut self, card_number: &'a str) -> &mut Self {
+        self.params.card_number = Some(card_number);
+        self
+    }
+
+    pub fn city(&mut self, city: &'a str) -> &mut Self {
+        self.params.city = Some(city);
+        self
+    }
+
+    pub fn country(&mut self, country: &'a str) -> &mut Self {
+        self.params.country = Some(country);
+        self
+    }
+
+    pub fn cvv(&mut self, cvv: &'a str) -> &mut Self {
+        self.params.cvv = Some(cvv);
+        self
+    }
+
+    pub fn expiration_month(&mut self, expiration_month: &'a str) -> &mut Self {
+        self.params.expiration_month = Some(expiration_month);
+        self
+    }
+
+    pub fn expiration_year(&mut self, expiration_year: &'a str) -> &mut Self {
+        self.params.expiration_year = Some(expiration_year);
+        self
+    }
+
+    pub fn first_name(&mut self, first_name: &'a str) -> &mut Self {
+        self.params.first_name = Some(first_name);
+        self
+    }
+
+    pub fn last_name(&mut self, last_name: &'a str) -> &mut Self {
+        self.params.last_name = Some(last_name);
+        self
+    }
+
+    pub fn other(&mut self, other: &'a str) -> &mut Self {
+        self.params.other = Some(other);
+        self
+    }
+
+    pub fn postal_code(&mut self, postal_code: &'a str) -> &mut Self {
+        self.params.postal_code = Some(postal_code);
+        self
+    }
+    pub fn state(&mut self, state: &'a str) -> &mut Self {
+        self.params.state = Some(state);
+        self
+    }
+
+    pub fn nonce(&mut self, nonce: &'a str) -> &mut Self {
+        self.params.nonce = Some(nonce);
+        self
+    }
+
+    pub fn device_data(&mut self, device_data: &'a str) -> &mut Self {
+        self.params.device_data = Some(device_data);
+        self
+    }
+
+    pub fn build(&self) -> TeamCreate<'a> {
         TeamCreate {
             params: TeamCreateParams {
-                name: name,
-                params_optional: None,
+                name: self.params.name,
+                address_1: self.params.address_1,
+                address_2: self.params.address_2,
+                card_number: self.params.card_number,
+                city: self.params.city,
+                country: self.params.country,
+                cvv: self.params.cvv,
+                expiration_month: self.params.expiration_month,
+                expiration_year: self.params.expiration_year,
+                first_name: self.params.first_name,
+                last_name: self.params.last_name,
+                other: self.params.other,
+                postal_code: self.params.postal_code,
+                state: self.params.state,
+                nonce: self.params.nonce,
+                device_data: self.params.device_data,
             },
         }
     }
@@ -77,17 +145,6 @@ impl<'a> TeamCreate<'a> {
 pub struct TeamCreateParams<'a> {
     /// unique name of team
     pub name: &'a str,
-    /// parameters to pass to Heroku
-    #[serde(flatten)]
-    pub params_optional: Option<TeamCreateOptionalParams<'a>>,
-}
-
-/// Create a new team with optional parameters
-///
-/// [See Heroku documentation for more information about these paramters](https://devcenter.heroku.com/articles/platform-api-reference#team-create-optional-parameters)
-#[serde_with::skip_serializing_none]
-#[derive(Serialize, Clone, Debug)]
-pub struct TeamCreateOptionalParams<'a> {
     /// street address line 1
     pub address_1: Option<&'a str>,
     /// street address line 2
@@ -180,37 +237,78 @@ impl<'a> HerokuEndpoint<Team, (), TeamCreateByEAParams<'a>> for TeamCreateByEA<'
 ///
 /// [See Heroku documentation for more information about this endpoint](https://devcenter.heroku.com/articles/platform-api-reference#team-app-create)
 pub struct TeamAppCreate<'a> {
-    pub params: Option<TeamAppCreateParams<'a>>,
+    pub params: TeamAppCreateParams<'a>,
 }
 
 impl<'a> TeamAppCreate<'a> {
-    pub fn new(
-        locked: Option<bool>,
-        name: Option<&'a str>,
-        team: Option<&'a str>,
-        personal: Option<bool>,
-        region: Option<&'a str>,
-        space: Option<&'a str>,
-        stack: Option<&'a str>,
-        internal_routing: Option<bool>,
-    ) -> TeamAppCreate<'a> {
+    pub fn new() -> TeamAppCreate<'a> {
         TeamAppCreate {
-            params: Some(TeamAppCreateParams {
-                locked,
-                name,
-                team,
-                personal,
-                region,
-                space,
-                stack,
-                internal_routing,
-            }),
+            params: TeamAppCreateParams {
+                locked: None,
+                name: None,
+                team: None,
+                personal: None,
+                region: None,
+                space: None,
+                stack: None,
+                internal_routing: None,
+            },
         }
     }
 
-    /// Pass no parameters to the Heroku API
-    pub fn create() -> TeamAppCreate<'a> {
-        TeamAppCreate { params: None }
+    pub fn locked(&mut self, locked: bool) -> &mut Self {
+        self.params.locked = Some(locked);
+        self
+    }
+
+    pub fn name(&mut self, name: &'a str) -> &mut Self {
+        self.params.name = Some(name);
+        self
+    }
+
+    pub fn team(&mut self, team: &'a str) -> &mut Self {
+        self.params.team = Some(team);
+        self
+    }
+
+    pub fn personal(&mut self, personal: bool) -> &mut Self {
+        self.params.personal = Some(personal);
+        self
+    }
+
+    pub fn region(&mut self, region: &'a str) -> &mut Self {
+        self.params.region = Some(region);
+        self
+    }
+
+    pub fn space(&mut self, space: &'a str) -> &mut Self {
+        self.params.space = Some(space);
+        self
+    }
+
+    pub fn stack(&mut self, stack: &'a str) -> &mut Self {
+        self.params.stack = Some(stack);
+        self
+    }
+
+    pub fn internal_routing(&mut self, internal_routing: bool) -> &mut Self {
+        self.params.internal_routing = Some(internal_routing);
+        self
+    }
+
+    pub fn build(&self) -> TeamAppCreate<'a> {
+        TeamAppCreate {
+            params: TeamAppCreateParams {
+                locked: self.params.locked,
+                name: self.params.name,
+                team: self.params.team,
+                personal: self.params.personal,
+                region: self.params.region,
+                space: self.params.space,
+                stack: self.params.stack,
+                internal_routing: self.params.internal_routing,
+            },
+        }
     }
 }
 
@@ -250,7 +348,7 @@ impl<'a> HerokuEndpoint<TeamApp, (), TeamAppCreateParams<'a>> for TeamAppCreate<
         format!("teams/apps")
     }
     fn body(&self) -> Option<TeamAppCreateParams<'a>> {
-        self.params.clone()
+        Some(self.params.clone())
     }
 }
 
@@ -292,30 +390,30 @@ pub struct TeamMemberCreate<'a> {
 }
 
 impl<'a> TeamMemberCreate<'a> {
-    /// required and optional parameters
-    pub fn new(
-        team_id: &'a str,
-        email: &'a str,
-        role: &'a str,
-        federated: Option<bool>,
-    ) -> TeamMemberCreate<'a> {
-        TeamMemberCreate {
-            team_id,
-            params: TeamMemberCreateParams {
-                email,
-                role,
-                federated,
-            },
-        }
-    }
     /// Only required parameters passed
-    pub fn create(team_id: &'a str, email: &'a str, role: &'a str) -> TeamMemberCreate<'a> {
+    pub fn new(team_id: &'a str, email: &'a str, role: &'a str) -> TeamMemberCreate<'a> {
         TeamMemberCreate {
             team_id,
             params: TeamMemberCreateParams {
                 email: email,
                 role: role,
                 federated: None,
+            },
+        }
+    }
+
+    pub fn federated(&mut self, federated: bool) -> &mut Self {
+        self.params.federated = Some(federated);
+        self
+    }
+
+    pub fn build(&self) -> TeamMemberCreate<'a> {
+        TeamMemberCreate {
+            team_id: self.team_id,
+            params: TeamMemberCreateParams {
+                email: self.params.email,
+                role: self.params.role,
+                federated: self.params.federated,
             },
         }
     }

--- a/src/endpoints/teams/put.rs
+++ b/src/endpoints/teams/put.rs
@@ -16,14 +16,28 @@ pub struct TeamInvitationCreate<'a> {
 }
 
 impl<'a> TeamInvitationCreate<'a> {
-    pub fn new(
-        team_id: &'a str,
-        email: &'a str,
-        role: Option<&'a str>,
-    ) -> TeamInvitationCreate<'a> {
+    pub fn new(team_id: &'a str, email: &'a str) -> TeamInvitationCreate<'a> {
         TeamInvitationCreate {
             team_id,
-            params: TeamInvitationCreateParams { email, role },
+            params: TeamInvitationCreateParams {
+                email: email,
+                role: None,
+            },
+        }
+    }
+
+    pub fn role(&mut self, role: &'a str) -> &mut Self {
+        self.params.role = Some(role);
+        self
+    }
+
+    pub fn build(&self) -> TeamInvitationCreate<'a> {
+        TeamInvitationCreate {
+            team_id: self.team_id,
+            params: TeamInvitationCreateParams {
+                email: self.params.email,
+                role: self.params.role,
+            },
         }
     }
 }
@@ -70,30 +84,30 @@ pub struct TeamMemberCreateorUpdate<'a> {
 }
 
 impl<'a> TeamMemberCreateorUpdate<'a> {
-    /// required and optional parameters
-    pub fn new(
-        team_id: &'a str,
-        email: &'a str,
-        role: &'a str,
-        federated: Option<bool>,
-    ) -> TeamMemberCreateorUpdate<'a> {
-        TeamMemberCreateorUpdate {
-            team_id,
-            params: TeamMemberCreateorUpdateParams {
-                email,
-                role,
-                federated,
-            },
-        }
-    }
     /// Only required parameters passed
-    pub fn create(team_id: &'a str, email: &'a str, role: &'a str) -> TeamMemberCreateorUpdate<'a> {
+    pub fn new(team_id: &'a str, email: &'a str, role: &'a str) -> TeamMemberCreateorUpdate<'a> {
         TeamMemberCreateorUpdate {
             team_id,
             params: TeamMemberCreateorUpdateParams {
                 email: email,
                 role: role,
                 federated: None,
+            },
+        }
+    }
+
+    pub fn federated(&mut self, federated: bool) -> &mut Self {
+        self.params.federated = Some(federated);
+        self
+    }
+
+    pub fn build(&self) -> TeamMemberCreateorUpdate<'a> {
+        TeamMemberCreateorUpdate {
+            team_id: self.team_id,
+            params: TeamMemberCreateorUpdateParams {
+                email: self.params.email,
+                role: self.params.role,
+                federated: self.params.federated,
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! # Example 1 - Creating a simple client
 //!
 //! ```rust
-//! use heroku_rs::framework::{apiclient::HerokuApiClient, HttpApiClient};
+//! use heroku_rs::prelude::*;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!    let api_client = HttpApiClient::create("API_KEY")?;
@@ -40,8 +40,7 @@
 //!
 //!
 //! ```rust
-//!use heroku_rs::framework::{apiclient::HerokuApiClient, HttpApiClient};
-//!use heroku_rs::endpoints::apps;
+//!use heroku_rs::prelude::*;
 //!
 //!# fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!#

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@
 //!
 //! Creating the Heroku client only takes 1 line. This client has the default 30s http timeout and points to the production Heroku API.
 //!
-//! If you wish to custumize the http timeout or the base endpoint. See the Example 2
-//!
 //! # Example 1 - Creating a simple client
 //!
 //! ```rust
@@ -32,32 +30,9 @@
 //!    Ok(())
 //! }
 //! ```
-//! In order to have a fully functional custom client you need to specify three things. [Credentials][credentials], [HttpApiClientConfig][httpApiClientConfig] and [ApiEnvironment][apiEnviroment]
+//! If you want a custom client, you need to specify three things. [Credentials][credentials], [HttpApiClientConfig][httpApiClientConfig] and [ApiEnvironment][apiEnviroment] See this [example][example_custom]
+//! 
 //!
-//! # Example 2 - Creating a custom client
-//! ```
-//! use heroku_rs::framework::{
-//! auth::Credentials,
-//! apiclient::HerokuApiClient,
-//! ApiEnvironment, HttpApiClient, HttpApiClientConfig,
-//! };
-//!
-//! use heroku_rs::endpoints::apps;
-//!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!
-//!   let api_client = HttpApiClient::create("API_KEY")?;
-//!   
-//!   let response = api_client.request(&apps::AppList {});
-//!   
-//!   match response {
-//!       Ok(success) => println!("Success: {:#?}", success),
-//!       Err(e) => println!("Error: {}", e),
-//!   }
-//!   
-//!   Ok(())
-//! }
-//! ```
 //! ## Making a GET request to Heroku.
 //!
 //!
@@ -93,23 +68,14 @@
 //! If you can see the `params` parameter in this example, it takes three fields, all three are optional, matched from the Heroku documentation.
 //!
 //! ```rust
-//!use heroku_rs::framework::{apiclient::HerokuApiClient, HttpApiClient};
-//!use heroku_rs::endpoints::apps;
+//!use heroku_rs::prelude::*;
 //!
 //!# fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!#
 //!    let api_client = HttpApiClient::create("API_KEY")?;
 //!
-//!    let app_name = String::from("FOO");
-//!
-//!    let response = api_client.request(&apps::AppCreate {
-//!        // This will create an app with the name name `FOO_APP`
-//!        params: apps::AppCreateParams {
-//!            name: Some(app_name),
-//!            region: None,
-//!            stack: None,
-//!        },
-//!    });
+//!    let new_app = &apps::AppCreate::new().name("FOO").build();
+//!    let response = api_client.request(new_app);
 //!
 //!    match response {
 //!       Ok(success) => println!("Success: {:#?}", success),
@@ -130,17 +96,14 @@
 //!
 //!
 //! ```rust
-//!use heroku_rs::framework::{apiclient::HerokuApiClient, HttpApiClient};
-//!use heroku_rs::endpoints::apps;
+//!use heroku_rs::prelude::*;
 //!
 //!# fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!
 //!    let api_client = HttpApiClient::create("API_KEY")?;
 //!
-//!    let app_id = String::from("FOO");
-//!
 //!    // This will delete the `FOO` app.
-//!    let response = api_client.request(&apps::AppDelete { app_id });
+//!    let response = api_client.request(&apps::AppDelete::new("FOO"));
 //!
 //!    match response {
 //!       Ok(success) => println!("Success: {:#?}", success),
@@ -155,28 +118,20 @@
 //! ## Making PATCH requests to Heroku.
 //!
 //!
-//! Similar to POST requests, Some PATCH requests do not need body paramers.
-//!
+//! Similar to POST requests, Some PATCH requests do not need body paramers, in this case we are updating the app name from "FOO" to "BAZ" and turning maintenance off.
 //!
 //! ```rust
-//!use heroku_rs::framework::{apiclient::HerokuApiClient, HttpApiClient};
-//!use heroku_rs::endpoints::apps;
+//!use heroku_rs::prelude::*;
 //!
 //!# fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!
 //!    let api_client = HttpApiClient::create("API_KEY")?;
 //!
-//!    let app_id = String::from("FOO");
-//!
-//!    // This will enable maintenance for the "FOO" app.
-//!     let response = api_client.request(&apps::AppUpdate {
-//!         app_id,
-//!         params: apps::AppUpdateParams {
-//!             build_stack: None,
-//!             maintenance: Some(true),
-//!             name: None,
-//!         },
-//!     });
+//!    let patch = &apps::AppUpdate::new("FOO")
+//!         .name("BAZ")
+//!         .maintenance(false)
+//!         .build();
+//!    let response = api_client.request(patch);
 //!
 //!    match response {
 //!       Ok(success) => println!("Success: {:#?}", success),
@@ -194,6 +149,7 @@
 //! [apiEnviroment]: framework/enum.ApiEnvironment.html
 //! [httpApiClientConfig]: framework/struct.HttpApiClientConfig.html
 //! [credentials]: framework/auth/enum.Credentials.html
+//! [example_custom]: https://github.com/bensadiku/heroku_rs/blob/5d26382089b608cc7dcb08ebd921aa7320e228f8/examples/src/main.rs#L57
 
 extern crate chrono;
 extern crate reqwest;

--- a/tests/apps.rs
+++ b/tests/apps.rs
@@ -18,7 +18,7 @@ mod tests {
     fn assert_valid_url_get_app_details() {
         let app_id = "123xyz";
         let response = util::get_client().request(&apps::AppDetails {
-            app_id: app_id.to_owned(),
+            app_id: app_id,
         });
         let endpoint = format!("{}{}", "apps/", app_id);
         assert_valid_url(response, endpoint)

--- a/tests/dynos.rs
+++ b/tests/dynos.rs
@@ -12,7 +12,7 @@ mod tests {
     fn assert_valid_url_get_dyno_list() {
         let app_id = "123xyz";
         let response = util::get_client().request(&dynos::DynoList {
-            app_id: app_id.to_owned(),
+            app_id: app_id,
         });
         let endpoint = format!("{}{}{}", "apps/", app_id, "/dynos");
         assert_valid_url(response, endpoint)
@@ -23,8 +23,8 @@ mod tests {
         let app_id = "123xyz";
         let dyno_id = "xyz123";
         let response = util::get_client().request(&dynos::DynoActionStop {
-            app_id: app_id.to_owned(),
-            dyno_id: dyno_id.to_owned(),
+            app_id: app_id,
+            dyno_id: dyno_id,
         });
         let endpoint = format!(
             "{}{}{}{}{}",
@@ -37,9 +37,9 @@ mod tests {
     fn assert_valid_url_dyno_create() {
         let app_id = "123xyz";
         let response = util::get_client().request(&dynos::DynoCreate {
-            app_id: app_id.to_owned(),
+            app_id: app_id,
             params: dynos::DynoCreateParams {
-                command: "bash".to_owned(),
+                command: "bash",
                 attach: None,
                 env: None,
                 force_no_tty: None,

--- a/tests/pipelines.rs
+++ b/tests/pipelines.rs
@@ -18,7 +18,7 @@ mod tests {
     fn assert_valid_url_get_pipeline_details() {
         let pipeline_id = "123xyz";
         let response = util::get_client().request(&pipelines::PipelineDetails {
-            pipeline_id: pipeline_id.to_owned(),
+            pipeline_id: pipeline_id,
         });
         let endpoint = format!("{}{}", "pipelines/", pipeline_id);
         assert_valid_url(response, endpoint)
@@ -28,7 +28,7 @@ mod tests {
     fn assert_valid_url_get_pipeline_coupling_details() {
         let coupling_id = "123xyz";
         let response = util::get_client().request(&pipelines::PipelineCouplingDetails {
-            coupling_id: coupling_id.to_owned(),
+            coupling_id: coupling_id,
         });
         let endpoint = format!("{}{}", "pipeline-couplings/", coupling_id);
         assert_valid_url(response, endpoint)

--- a/tests/releases.rs
+++ b/tests/releases.rs
@@ -12,7 +12,7 @@ mod tests {
     fn assert_valid_url_get_release_list() {
         let app_id = "123xyz";
         let response = util::get_client().request(&releases::ReleaseList {
-            app_id: app_id.to_owned(),
+            app_id: app_id,
         });
 
         let endpoint = format!("{}{}{}", "apps/", app_id, "/releases");
@@ -24,8 +24,8 @@ mod tests {
         let app_id = "123xyz";
         let release_id = "456abc";
         let response = util::get_client().request(&releases::ReleaseInfo {
-            app_id: app_id.to_owned(),
-            release_id: release_id.to_owned(),
+            app_id: app_id,
+            release_id: release_id,
         });
 
         let endpoint = format!("{}{}{}{}", "apps/", app_id, "/releases/", release_id);
@@ -36,10 +36,10 @@ mod tests {
     fn assert_valid_url_release_create() {
         let app_id = "123xyz";
         let response = util::get_client().request(&releases::ReleaseCreate {
-            app_id: app_id.to_owned(),
+            app_id: app_id,
             params: releases::ReleaseCreateParams {
-                slug: "fooslug".to_string(),
-                description: Some("releasing the thing".to_string()),
+                slug: "fooslug",
+                description: Some("releasing the thing"),
             },
         });
         let endpoint = format!("{}{}{}", "apps/", app_id, "/releases");
@@ -51,9 +51,9 @@ mod tests {
         let app_id = "123xyz";
 
         let response = util::get_client().request(&releases::ReleaseRollback {
-            app_id: app_id.to_owned(),
+            app_id: app_id,
             params: releases::ReleaseRollbackParams {
-                release: "v40".to_string(),
+                release: "v40",
             },
         });
         let endpoint = format!("{}{}{}", "apps/", app_id, "/releases");

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -39,7 +39,7 @@ mod tests {
     fn assert_valid_url_get_dyno_list() {
         let region_id = "123xyz";
         let response = get_client().request(&misc::RegionDetails {
-            region_id: region_id.to_owned(),
+            region_id: region_id,
         });
         let endpoint = format!("{}{}", "regions/", region_id);
         assert_valid_url(response, endpoint)


### PR DESCRIPTION
Added some builder pattern logic to expose a more simple and idiomatic API.

Example, if you wanna create a invoice address with 2 addresses and a use_invoice_address boolean.

Example before: (now removed)
```rust
let response = api_client.request(&account::InvoiceAddressUpdate::new(
       String::from("Grove Street"), 
       String::from("Not Grove Street"),
       None, 
       None,
       None, 
       None,
       None, 
       Some(true),
));
//match response
```
Often times, a more verbose implementation(Still available, with `&str` instead of `String`):
```rust
 let response = api_client.request(&account::InvoiceAddressUpdate {
        params: account::InvoiceAddressUpdateParams {
            address_1: Some(String::from("Grove Street")),
            address_2: Some(String::from("Not Grove Street")),
            city: None,
            country: None,
            other: None,
            postal_code: None,
            state: None,
            use_invoice_address: Some(true),
        },
    });
//match response
```
Every field of the InvoiceAddressUpdate had to be explicitly but  unnecessarily defined.


New approach:
```rust
  let response =  api_client.request(&account::InvoiceAddressUpdate::new()
        .address_1("Grove Street")
        .address_2("Not Grove Street")
        .use_invoice_address(true)
        .build());
//match response
```

This completely removes the need to access the struct fields manually. However, the old way to access structs and param structs will still be available. No breaking changes there (except for strings, see below).

This also removes `String` from struct fields completely, now it's using `str` for the most part, therefore, will introduce some minor breaking changes.

This also removed `create` methods which took only required parameters, replaces with the new implemtentation of `new`.

All examples and tests are updated too.