### PR TITLE
Macros for Heroku objects

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "example01"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "dotenv",
  "heroku_rs",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "heroku_rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "failure",

--- a/examples/src/macro_examples.rs
+++ b/examples/src/macro_examples.rs
@@ -1,0 +1,39 @@
+use super::print_response;
+use heroku_rs::prelude::*;
+
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app_name = "heroku-rs-tests";
+
+    let token = dotenv::var("API_KEY").unwrap();
+
+    // This will use the default headers & timeout for the HttpApiClientConfig
+    // and will use the default production heroku endpoint
+    let api_client = &HttpApiClient::create(&token)?;
+
+    // create_dyno(api_client, app_name);
+    create_slug(api_client, app_name);
+
+    Ok(())
+}
+
+/// create a dyno
+fn create_dyno<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let env_vars = heroku_env!["COLUMNS" => "80", "LINES" => "24",];
+    let new_dyno_complex = &DynoCreate::new(app_id, "bash")
+        .attach(true)
+        .env(env_vars)
+        .build();
+
+    let response = api_client.request(new_dyno_complex);
+
+    print_response(response);
+}
+
+/// create a slug
+fn create_slug<T: HerokuApiClient>(api_client: &T, app_id: &str) {
+    let process_types = heroku_env!["web" => "./bin/web -p $PORT"];
+
+    let response = api_client.request(&SlugCreate::new(app_id, process_types));
+
+    print_response(response);
+}

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)] //Some methods may not be "used" because they're showcase examples and not called all at once
-extern crate heroku_rs;
+#[macro_use] extern crate heroku_rs;
 use dotenv;
 use heroku_rs::framework::{
     auth::Credentials,
@@ -21,6 +21,7 @@ mod pipeline_examples;
 mod spaces_examples;
 mod teams_examples;
 mod testing_examples;
+mod macro_examples;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let key = "API_KEY";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,8 @@ extern crate reqwest;
 #[macro_use]
 extern crate serde;
 extern crate serde_json;
+#[macro_use]
+pub mod macros;
 
 pub mod endpoints;
 pub mod framework;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,0 +1,54 @@
+#[macro_export]
+
+macro_rules! heroku_env {
+    ($($element: expr => $value: expr),* $(,)?) => {{
+        const SIZE: usize = ($crate::count![@COUNT; $($element),*]);
+        #[allow(unused_mut)]
+        let mut vs = ::std::collections::HashMap::with_capacity(SIZE);
+        $(vs.insert($element, $value);)*
+        vs
+    }};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! count {
+    (@COUNT; $($element:expr),*)=>{
+        <[()]>::len(&[$($crate::count![@SUBST; $element]),*])
+    };
+
+    (@SUBST; $_element:expr)=>{ () };
+}
+
+#[test]
+fn empty_map() {
+    use std::collections::HashMap;
+    let x: HashMap<&str, &str> = heroku_env![];
+    assert_eq!(true, x.is_empty())
+}
+
+#[test]
+fn trailing_comma() {
+    let _x = heroku_env!["a" => "b",];
+}
+
+#[test]
+fn one_element() {
+    let x = heroku_env!["foo" => "baz"];
+    assert_eq!(x.get("foo").unwrap(), &"baz");
+}
+
+#[test]
+fn multiple_elements() {
+    let x = heroku_env!["foo" => "baz", "a" => "b"];
+    assert_eq!(x.get("foo").unwrap(), &"baz");
+    assert_eq!(x.get("a").unwrap(), &"b");
+    assert_eq!(x.get("test3"), None);
+}
+
+#[allow(dead_code)]
+/// ```compile_fail
+/// use std::collections::HashMap;
+/// let x: HashMap<&str, &str> = heroku_env!["foo"];
+/// ```
+struct CompileFailTest;


### PR DESCRIPTION
Declarative macros for Heroku objects.

Before:

```rust
use std::collections::HashMap;

let mut env_vars = HashMap::new();

custom_env_vars.insert("COLUMNS", "80");
custom_env_vars.insert("LINES", "24");
```

After:
```rust
 let env_vars = heroku_env!["COLUMNS" => "80", "LINES" => "24"];
```