### PR TITLE
Empty response on DynoActionStop

### DIFF
--- a/src/endpoints/dynos/post.rs
+++ b/src/endpoints/dynos/post.rs
@@ -44,7 +44,7 @@ impl<'a> DynoActionStop<'a> {
     }
 }
 
-impl<'a> HerokuEndpoint<Dyno> for DynoActionStop<'a> {
+impl<'a> HerokuEndpoint for DynoActionStop<'a> {
     fn method(&self) -> Method {
         Method::Post
     }


### PR DESCRIPTION
Heroku returns an empty response on a dyno stop

```bash
$ curl -n -X POST https://api.heroku.com/apps/my-app/dynos/my-dyno/actions/stop \
  -H "Content-Type: application/json" \
  -H "Accept: application/vnd.heroku+json; version=3"

# response
{} 
```